### PR TITLE
feat: goal history per task + soft-delete goals

### DIFF
--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -505,6 +505,8 @@ public class StudyGoal {
     
     /**
      * Get study goals for a specific date.
+     * Failed goals are excluded — use {@link #findAllByDate(LocalDate)} for views
+     * that need the complete history (e.g. calendar).
      */
     public static List<StudyGoal> findByDate(LocalDate date) {
         if (jdbcTemplate == null || date == null) {
@@ -524,6 +526,25 @@ public class StudyGoal {
         logger.debug("Retrieved {} study goals for date: {}", goals.size(), date);
         return goals;
     }
+
+    /**
+     * Get all study goals for a specific date, including failed ones.
+     * Used by calendar view which shows the full history for each day.
+     */
+    public static List<StudyGoal> findAllByDate(LocalDate date) {
+        if (jdbcTemplate == null || date == null) {
+            return List.of();
+        }
+
+        String sql = """
+            SELECT * FROM study_goals
+            WHERE (date = ? OR replanned_for_date = ?)
+            ORDER BY failed ASC, achieved DESC, created_at ASC
+            """;
+        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date);
+        logger.debug("Retrieved {} study goals (all statuses) for date: {}", goals.size(), date);
+        return goals;
+    }
     
     /**
      * Get study goals for a specific date including delayed goals that should appear on this date.
@@ -532,7 +553,7 @@ public class StudyGoal {
      *   <li>Goals originally created for the specified date</li>
      *   <li>Unachieved goals from previous dates that are now delayed</li>
      * </ul>
-     * 
+     *
      * @param date the date to retrieve goals for
      * @return list of study goals including delayed ones, ordered by delay status and creation time
      */
@@ -540,7 +561,7 @@ public class StudyGoal {
         if (jdbcTemplate == null || date == null) {
             return List.of();
         }
-        
+
         // Delayed goals that were manually replanned are excluded from the automatic
         // carry-forward path — they only surface via their replanned_for_date.
         // Failed goals are excluded from active planner views.
@@ -555,6 +576,28 @@ public class StudyGoal {
 
         List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date, date);
         logger.debug("Retrieved {} study goals (including delayed) for date: {}", goals.size(), date);
+        return goals;
+    }
+
+    /**
+     * Like {@link #findByDateIncludingDelayed(LocalDate)} but includes failed goals.
+     * Used by calendar view which shows all goals for each day.
+     */
+    public static List<StudyGoal> findAllByDateIncludingDelayed(LocalDate date) {
+        if (jdbcTemplate == null || date == null) {
+            return List.of();
+        }
+
+        String sql = """
+            SELECT * FROM study_goals
+            WHERE (date = ?
+               OR (is_delayed = TRUE AND achieved = FALSE AND failed = FALSE AND date < ? AND replanned_for_date IS NULL)
+               OR replanned_for_date = ?)
+            ORDER BY failed ASC, is_delayed ASC, days_delayed DESC, created_at ASC
+            """;
+
+        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date, date);
+        logger.debug("Retrieved {} study goals (all statuses, including delayed) for date: {}", goals.size(), date);
         return goals;
     }
     

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -98,6 +98,9 @@ public class StudyGoal {
      */
     private LocalDate replannedForDate;
 
+    /** Whether this goal has been marked as failed (overdue beyond threshold or user-dismissed). */
+    private boolean failed;
+
     /**
      * Default constructor creating a study goal with auto-generated ID and current date.
      * 
@@ -110,6 +113,7 @@ public class StudyGoal {
         this.daysDelayed = 0;
         this.isDelayed = false;
         this.pointsDeducted = 0;
+        this.failed = false;
     }
 
     /**
@@ -177,12 +181,24 @@ public class StudyGoal {
 
     /**
      * Full constructor including the optional replanned-for date.
-     * Used by the row mapper and when rescheduling goals.
+     * Used when rescheduling goals (failed defaults to false).
      */
     public StudyGoal(String id, LocalDate date, String description, boolean achieved,
                     String reasonIfNotAchieved, int daysDelayed,
                     boolean isDelayed, int pointsDeducted, String taskId,
                     LocalDate replannedForDate) {
+        this(id, date, description, achieved, reasonIfNotAchieved,
+             daysDelayed, isDelayed, pointsDeducted, taskId, replannedForDate, false);
+    }
+
+    /**
+     * Full constructor including failed flag.
+     * Used by the row mapper.
+     */
+    public StudyGoal(String id, LocalDate date, String description, boolean achieved,
+                    String reasonIfNotAchieved, int daysDelayed,
+                    boolean isDelayed, int pointsDeducted, String taskId,
+                    LocalDate replannedForDate, boolean failed) {
         this.id = id != null ? id : java.util.UUID.randomUUID().toString();
         this.date = date != null ? date : LocalDate.now();
         this.description = description;
@@ -193,6 +209,7 @@ public class StudyGoal {
         this.pointsDeducted = pointsDeducted;
         this.taskId = taskId;
         this.replannedForDate = replannedForDate;
+        this.failed = failed;
     }
 
     /**
@@ -349,6 +366,20 @@ public class StudyGoal {
     }
 
     /**
+     * Checks if this goal has been marked as failed.
+     *
+     * @return true if the goal is failed
+     */
+    public boolean isFailed() { return failed; }
+
+    /**
+     * Sets whether this goal is failed.
+     *
+     * @param failed true to mark as failed
+     */
+    public void setFailed(boolean failed) { this.failed = failed; }
+
+    /**
      * Calculate the delay penalty based on days delayed.
      * Formula: 5 points for first delay, then 2 points per additional day.
      * 
@@ -400,14 +431,14 @@ public class StudyGoal {
         String sql = """
             MERGE INTO study_goals (id, date, description, achieved, reason_if_not_achieved,
                                    days_delayed, is_delayed, points_deducted, task_id,
-                                   replanned_for_date, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                                   replanned_for_date, failed, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             """;
 
         jdbcTemplate.update(sql,
             this.id, this.date, this.description, this.achieved, this.reasonIfNotAchieved,
             this.daysDelayed, this.isDelayed, this.pointsDeducted, this.taskId,
-            this.replannedForDate
+            this.replannedForDate, this.failed
         );
         
         logger.debug("StudyGoal saved: {} - {}", this.id, this.description);
@@ -482,10 +513,11 @@ public class StudyGoal {
 
         // Include goals originally planned for this date AND goals manually
         // rescheduled (replanned) to appear on this date, regardless of achieved status.
+        // Failed goals are excluded from active views.
         String sql = """
             SELECT * FROM study_goals
-            WHERE date = ?
-               OR replanned_for_date = ?
+            WHERE (failed = FALSE OR failed IS NULL)
+              AND (date = ? OR replanned_for_date = ?)
             ORDER BY created_at
             """;
         List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date);
@@ -511,11 +543,13 @@ public class StudyGoal {
         
         // Delayed goals that were manually replanned are excluded from the automatic
         // carry-forward path — they only surface via their replanned_for_date.
+        // Failed goals are excluded from active planner views.
         String sql = """
             SELECT * FROM study_goals
-            WHERE date = ?
+            WHERE (failed = FALSE OR failed IS NULL)
+              AND (date = ?
                OR (is_delayed = TRUE AND achieved = FALSE AND date < ? AND replanned_for_date IS NULL)
-               OR replanned_for_date = ?
+               OR replanned_for_date = ?)
             ORDER BY is_delayed ASC, days_delayed DESC, created_at ASC
             """;
 
@@ -637,11 +671,34 @@ public class StudyGoal {
         String sql = """
             SELECT * FROM study_goals
             WHERE task_id = ?
+              AND (failed = FALSE OR failed IS NULL)
               AND (date = ? OR replanned_for_date = ?)
             ORDER BY is_delayed ASC, date ASC, created_at ASC
             """;
         List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), taskId, date, date);
         logger.debug("Retrieved {} goals for task {} on date {}", goals.size(), taskId, date);
+        return goals;
+    }
+
+    /**
+     * Find ALL goals ever linked to a specific task, including failed ones.
+     * Used for the goal history view in the task management panel.
+     *
+     * @param taskId the task ID to find all linked goals for
+     * @return list of all study goals (active, achieved, failed) linked to the task, ordered by date desc
+     */
+    public static List<StudyGoal> findByTaskId(String taskId) {
+        if (jdbcTemplate == null || taskId == null || taskId.isBlank()) {
+            return List.of();
+        }
+
+        String sql = """
+            SELECT * FROM study_goals
+            WHERE task_id = ?
+            ORDER BY date DESC, created_at DESC
+            """;
+        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), taskId);
+        logger.debug("Retrieved {} total goals for task {}", goals.size(), taskId);
         return goals;
     }
 
@@ -711,6 +768,7 @@ public class StudyGoal {
         String sql = """
             SELECT * FROM study_goals
             WHERE task_id IS NULL
+              AND (failed = FALSE OR failed IS NULL)
               AND (date = ? OR replanned_for_date = ?)
             ORDER BY is_delayed ASC, date ASC, created_at ASC
             """;
@@ -733,6 +791,7 @@ public class StudyGoal {
             SELECT * FROM study_goals
             WHERE is_delayed = TRUE
               AND achieved = FALSE
+              AND (failed = FALSE OR failed IS NULL)
               AND replanned_for_date IS NULL
             ORDER BY days_delayed DESC, date ASC, created_at ASC
             """;
@@ -756,9 +815,10 @@ public class StudyGoal {
             int pointsDeducted = rs.getInt("points_deducted");
             String taskId = rs.getString("task_id");
             LocalDate replannedForDate = rs.getObject("replanned_for_date", LocalDate.class);
+            boolean failed = rs.getBoolean("failed");
 
             return new StudyGoal(id, date, description, achieved, reasonIfNotAchieved,
-                               daysDelayed, isDelayed, pointsDeducted, taskId, replannedForDate);
+                               daysDelayed, isDelayed, pointsDeducted, taskId, replannedForDate, failed);
         };
     }
 }

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -566,7 +566,7 @@ public class StudyGoal {
             throw new IllegalStateException("JdbcTemplate not initialized");
         }
         
-        String sql = "SELECT * FROM study_goals WHERE achieved = TRUE ORDER BY date DESC";
+        String sql = "SELECT * FROM study_goals WHERE achieved = TRUE AND (failed = FALSE OR failed IS NULL) ORDER BY date DESC";
         List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper());
         logger.debug("Retrieved {} achieved study goals", goals.size());
         return goals;
@@ -601,7 +601,7 @@ public class StudyGoal {
             return 0L;
         }
         
-        String sql = "SELECT COUNT(*) FROM study_goals WHERE achieved = ?";
+        String sql = "SELECT COUNT(*) FROM study_goals WHERE achieved = ? AND (failed = FALSE OR failed IS NULL)";
         Integer count = jdbcTemplate.queryForObject(sql, Integer.class, achieved);
         return count != null ? count : 0L;
     }
@@ -721,6 +721,7 @@ public class StudyGoal {
         String sql = """
             SELECT DISTINCT task_id, date FROM study_goals
             WHERE achieved = TRUE
+              AND (failed = FALSE OR failed IS NULL)
               AND task_id IS NOT NULL
               AND date IS NOT NULL
               AND date >= ? AND date <= ?
@@ -749,6 +750,7 @@ public class StudyGoal {
         String sql = """
             SELECT COUNT(*) FROM study_goals
             WHERE task_id = ? AND date = ? AND achieved = TRUE
+              AND (failed = FALSE OR failed IS NULL)
             """;
         Integer count = jdbcTemplate.queryForObject(sql, Integer.class, taskId, date);
         return count != null && count > 0;

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -87,6 +87,30 @@ public class StudyService {
     }
 
     /**
+     * Get all study goals for a date including failed ones.
+     * Used by calendar view which shows the complete history for each day.
+     */
+    public List<StudyGoal> getAllGoalsForDate(LocalDate date) {
+        ensureDelayedGoalsProcessedToday();
+        return StudyGoal.findAllByDateIncludingDelayed(date);
+    }
+
+    /**
+     * Get all study goals planned for a future date including failed ones.
+     */
+    @Transactional(readOnly = true)
+    public List<StudyGoal> getAllGoalsForFutureDate(LocalDate date) {
+        if (date == null) {
+            throw ValidationException.requiredFieldMissing("date");
+        }
+        if (!date.isAfter(dateTimeService.getCurrentDate())) {
+            throw ValidationException.invalidDateRange(
+                date.toString(), "a future date");
+        }
+        return StudyGoal.findAllByDate(date);
+    }
+
+    /**
      * Get study goals planned for a future date.
      * Skips delay processing since future dates cannot have delayed goals.
      * 
@@ -228,9 +252,9 @@ public class StudyService {
 
     /**
      * Soft-deletes a study goal by marking it as failed.
-     * Goals are never physically deleted — they are kept for historical logging.
+     * The goal is preserved for historical display on its planned date.
      */
-    public boolean deleteStudyGoal(String goalId) {
+    public boolean markGoalAsFailed(String goalId) {
         if (goalId == null || goalId.isBlank()) {
             throw ValidationException.requiredFieldMissing("goalId");
         }
@@ -241,12 +265,29 @@ public class StudyService {
             goal.setAchieved(false);
             goal.save();
             markDirty();
-            logger.info("Soft-deleted study goal '{}' (marked as failed)", goalId);
+            logger.info("Marked study goal '{}' as failed", goalId);
             return true;
         } else {
-            logger.warn("Requested deletion for study goal '{}' but it did not exist", goalId);
+            logger.warn("Requested mark-as-failed for study goal '{}' but it did not exist", goalId);
             return false;
         }
+    }
+
+    /**
+     * Permanently deletes a study goal from the database.
+     */
+    public boolean deleteStudyGoal(String goalId) {
+        if (goalId == null || goalId.isBlank()) {
+            throw ValidationException.requiredFieldMissing("goalId");
+        }
+        boolean deleted = StudyGoal.deleteById(goalId);
+        if (deleted) {
+            markDirty();
+            logger.info("Permanently deleted study goal '{}'", goalId);
+        } else {
+            logger.warn("Requested deletion for study goal '{}' but it did not exist", goalId);
+        }
+        return deleted;
     }
 
     public StudySession startStudySession() {

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -365,11 +365,27 @@ public class StudyService {
                 continue;
             }
 
-            // Protect replanned goals only while the replan date
-            // hasn't passed yet (user still has a chance to complete it today).
-            // Once the replan date is in the past and the goal is still unachieved,
-            // fall through to the normal 14-day failure logic.
-            if (goal.getReplannedForDate() != null && !goal.getReplannedForDate().isBefore(today)) {
+            // Re-planned goals whose replan date has passed without being achieved
+            // must be marked as failed immediately — otherwise they vanish from all
+            // views (queries only match date or replanned_for_date equal to display date).
+            if (goal.getReplannedForDate() != null && goal.getReplannedForDate().isBefore(today)) {
+                String goalLabel = (goal.getDescription() != null && !goal.getDescription().isBlank())
+                        ? goal.getDescription()
+                        : goal.getId();
+                goal.setFailed(true);
+                goal.setDelayed(true);
+                int daysFromReplan = (int) ChronoUnit.DAYS.between(goal.getReplannedForDate(), today);
+                goal.setDaysDelayed(daysFromReplan);
+                goal.setPointsDeducted(calculateAccumulatedPenalty(daysFromReplan));
+                goal.save();
+                failedGoals++;
+                logger.info("Marked re-planned study goal '{}' as FAILED (replan date {} has passed)",
+                        goalLabel, goal.getReplannedForDate());
+                continue;
+            }
+
+            // Protect replanned goals on their replan date (user still has a chance today).
+            if (goal.getReplannedForDate() != null) {
                 continue;
             }
 

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -226,17 +226,26 @@ public class StudyService {
         }
     }
 
+    /**
+     * Soft-deletes a study goal by marking it as failed.
+     * Goals are never physically deleted — they are kept for historical logging.
+     */
     public boolean deleteStudyGoal(String goalId) {
         if (goalId == null || goalId.isBlank()) {
             throw ValidationException.requiredFieldMissing("goalId");
         }
-        boolean deleted = StudyGoal.deleteById(goalId);
-        if (deleted) {
+        Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
+        if (goalOpt.isPresent()) {
+            StudyGoal goal = goalOpt.get();
+            goal.setFailed(true);
+            goal.save();
             markDirty();
+            logger.info("Soft-deleted study goal '{}' (marked as failed)", goalId);
+            return true;
         } else {
             logger.warn("Requested deletion for study goal '{}' but it did not exist", goalId);
+            return false;
         }
-        return deleted;
     }
 
     public StudySession startStudySession() {
@@ -338,31 +347,31 @@ public class StudyService {
     /**
      * Process all goals and update delay penalties for overdue goals.
      * Only unachieved goals with dates in the past are considered delayed.
-     * Goals overdue by two weeks or more are automatically deleted.
+     * Goals overdue by two weeks or more are marked as FAILED (never deleted).
      * This should be called daily (e.g., via scheduled task or on app startup).
      *
-     * @return summary of how many goals were updated or auto-removed
+     * @return summary of how many goals were updated or marked failed
      */
     public GoalDelayProcessingResult processAllDelayedGoals() {
         LocalDate today = dateTimeService.getCurrentDate();
         List<StudyGoal> allGoals = StudyGoal.findAll();
         int updatedGoals = 0;
-        int removedGoals = 0;
-        
+        int failedGoals = 0;
+
         for (StudyGoal goal : allGoals) {
-            // Skip if goal is achieved
-            if (goal.isAchieved()) {
+            // Skip if goal is achieved or already marked failed
+            if (goal.isAchieved() || goal.isFailed()) {
                 continue;
             }
 
-            // Protect replanned goals from deletion only while the replan date
+            // Protect replanned goals only while the replan date
             // hasn't passed yet (user still has a chance to complete it today).
             // Once the replan date is in the past and the goal is still unachieved,
-            // fall through to the normal 14-day cleanup logic.
+            // fall through to the normal 14-day failure logic.
             if (goal.getReplannedForDate() != null && !goal.getReplannedForDate().isBefore(today)) {
                 continue;
             }
-            
+
             // Check if goal date is in the past (delayed)
             if (goal.getDate().isBefore(today)) {
                 int daysDelayed = (int) ChronoUnit.DAYS.between(goal.getDate(), today);
@@ -370,14 +379,15 @@ public class StudyService {
                     String goalLabel = (goal.getDescription() != null && !goal.getDescription().isBlank())
                         ? goal.getDescription()
                         : goal.getId();
-                    boolean deleted = StudyGoal.deleteById(goal.getId());
-                    if (deleted) {
-                        removedGoals++;
-                        logger.info("Removed study goal '{}' after {} days overdue",
-                                goalLabel, daysDelayed);
-                    } else {
-                        logger.warn("Failed to auto-remove overdue goal '{}'", goal.getId());
-                    }
+                    // Mark as failed instead of deleting — keeps history for logging
+                    goal.setFailed(true);
+                    goal.setDelayed(true);
+                    goal.setDaysDelayed(daysDelayed);
+                    goal.setPointsDeducted(calculateAccumulatedPenalty(daysDelayed));
+                    goal.save();
+                    failedGoals++;
+                    logger.info("Marked study goal '{}' as FAILED after {} days overdue",
+                            goalLabel, daysDelayed);
                     continue;
                 }
 
@@ -401,22 +411,22 @@ public class StudyService {
                 }
             }
         }
-        
-        if (updatedGoals > 0 || removedGoals > 0) {
+
+        if (updatedGoals > 0 || failedGoals > 0) {
             markDirty();
         }
 
-        return new GoalDelayProcessingResult(updatedGoals, removedGoals);
+        return new GoalDelayProcessingResult(updatedGoals, failedGoals);
     }
 
     /**
      * Summary of delayed-goal processing.
      * @param updatedGoals number of existing goals updated with delay metadata
-     * @param removedGoals number of goals deleted because they exceeded the delay threshold
+     * @param failedGoals number of goals marked as failed because they exceeded the delay threshold
      */
-    public record GoalDelayProcessingResult(int updatedGoals, int removedGoals) {
+    public record GoalDelayProcessingResult(int updatedGoals, int failedGoals) {
         public boolean hasChanges() {
-            return updatedGoals > 0 || removedGoals > 0;
+            return updatedGoals > 0 || failedGoals > 0;
         }
     }
     

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -238,6 +238,7 @@ public class StudyService {
         if (goalOpt.isPresent()) {
             StudyGoal goal = goalOpt.get();
             goal.setFailed(true);
+            goal.setAchieved(false);
             goal.save();
             markDirty();
             logger.info("Soft-deleted study goal '{}' (marked as failed)", goalId);

--- a/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
+++ b/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
@@ -278,8 +278,8 @@ public class StudySyncUI {
             if (result.updatedGoals() > 0) {
                 logger.info("Updated delay status for {} study goals carried over from previous days", result.updatedGoals());
             }
-            if (result.removedGoals() > 0) {
-                logger.info("Auto-removed {} study goals overdue by at least two weeks", result.removedGoals());
+            if (result.failedGoals() > 0) {
+                logger.info("Marked {} study goals as FAILED (overdue by at least two weeks)", result.failedGoals());
             }
         } catch (Exception e) {
             logger.error("Failed to process delayed goals on startup", e);

--- a/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
@@ -479,18 +479,16 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
     
     private List<StudyGoal> getFilteredStudyGoalsForDate(LocalDate date) {
         LocalDate today = LocalDate.now();
-        
+
         if (date.equals(today)) {
-            // For today, show all goals including delayed ones
-            return studyService.getStudyGoalsForDate(date);
+            return studyService.getAllGoalsForDate(date);
         } else if (date.isAfter(today)) {
-            // For future dates, show all goals planned for that date (no delay processing needed)
-            return studyService.getStudyGoalsForFutureDate(date);
+            return studyService.getAllGoalsForFutureDate(date);
         } else {
-            // For previous days, show only goals achieved that day OR goals originally set for that day
-            List<StudyGoal> allGoalsForDate = studyService.getStudyGoalsForDate(date);
+            // For previous days, show goals originally set for that day (all statuses)
+            List<StudyGoal> allGoalsForDate = studyService.getAllGoalsForDate(date);
             return allGoalsForDate.stream()
-                    .filter(goal -> goal.isAchieved() || goal.getDate().equals(date))
+                    .filter(goal -> goal.isAchieved() || goal.isFailed() || goal.getDate().equals(date))
                     .collect(Collectors.toList());
         }
     }
@@ -1015,11 +1013,14 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
     private VBox createStudyGoalBox(StudyGoal goal) {
         VBox goalBox = new VBox(8);
         goalBox.setPadding(new Insets(12));
-        
+
         String backgroundColor;
         String borderColor;
-        
-        if (goal.isAchieved()) {
+
+        if (goal.isFailed()) {
+            backgroundColor = "#fdecea";
+            borderColor = "#c0392b";
+        } else if (goal.isAchieved()) {
             backgroundColor = "#e8f5e8";
             borderColor = "#27ae60";
         } else if (goal.isDelayed()) {
@@ -1038,35 +1039,74 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             backgroundColor = "#fff5f5";
             borderColor = "#e74c3c";
         }
-        
+
         goalBox.setStyle("-fx-background-color: " + backgroundColor + "; -fx-background-radius: 8; -fx-border-color: " + borderColor + "; -fx-border-radius: 8;");
-        
+
         // Status and description
-        String statusIcon = goal.isAchieved() ? "\u2705" : (goal.isDelayed() ? "[!] " : "\u25CB");
-        String statusText = goal.isAchieved() ? "Achieved" : (goal.isDelayed() ? "Delayed" : "Pending");
-        
+        String statusIcon;
+        String statusText;
+        if (goal.isFailed()) {
+            statusIcon = "\u2715";
+            statusText = "Failed";
+        } else if (goal.isAchieved()) {
+            statusIcon = "\u2705";
+            statusText = "Achieved";
+        } else if (goal.isDelayed()) {
+            statusIcon = "[!] ";
+            statusText = "Delayed";
+        } else {
+            statusIcon = "\u25CB";
+            statusText = "Pending";
+        }
+
         Label statusLabel = new Label(statusIcon + " " + statusText);
         TaskStyleUtils.fontBold(statusLabel, 12);
-        
+        if (goal.isFailed()) {
+            statusLabel.setTextFill(Color.web("#c0392b"));
+        }
+
         Label descriptionLabel = new Label("\u25CE " + goal.getDescription());
         TaskStyleUtils.fontNormal(descriptionLabel, 13);
         descriptionLabel.setWrapText(true);
-        
+
         goalBox.getChildren().addAll(statusLabel, descriptionLabel);
-        
+
         // Add delay info if applicable
         if (goal.isDelayed()) {
-            Label delayLabel = new Label(String.format("» Originally from: %s • ♨ %d days delayed", 
+            Label delayLabel = new Label(String.format("» Originally from: %s • \u2668 %d days delayed",
                 goal.getDate().toString(), goal.getDaysDelayed()));
             TaskStyleUtils.fontNormal(delayLabel, 11);
             delayLabel.setTextFill(Color.web("#ff5722"));
             goalBox.getChildren().add(delayLabel);
         }
-        
+
         // Action buttons
         HBox actionBox = new HBox(8);
         actionBox.setAlignment(Pos.CENTER_RIGHT);
-        
+
+        // "Mark as Failed" button — soft-delete (only for active goals)
+        if (!goal.isAchieved() && !goal.isFailed()) {
+            Button failBtn = new Button("Mark as Failed");
+            failBtn.setGraphic(TaskStyleUtils.iconLabel("\u2716", 12));
+            failBtn.getStyleClass().addAll("btn-warning", "btn-small");
+            failBtn.setOnAction(e -> {
+                Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
+                confirmation.initOwner(goalBox.getScene() != null ? goalBox.getScene().getWindow() : null);
+                confirmation.setTitle("Mark Goal as Failed");
+                confirmation.setHeaderText("Mark this goal as failed?");
+                confirmation.setContentText("The goal will be kept in history as failed.\nGoal: " + goal.getDescription());
+
+                confirmation.showAndWait().ifPresent(response -> {
+                    if (response == ButtonType.OK) {
+                        studyService.markGoalAsFailed(goal.getId());
+                        updateCalendarDisplay();
+                    }
+                });
+            });
+            actionBox.getChildren().add(failBtn);
+        }
+
+        // Delete button — permanent removal
         Button deleteBtn = new Button("Delete");
         deleteBtn.setGraphic(TaskStyleUtils.iconLabel("\u2715", 12));
         deleteBtn.getStyleClass().addAll("btn-danger", "btn-small");
@@ -1074,9 +1114,9 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
             confirmation.initOwner(goalBox.getScene() != null ? goalBox.getScene().getWindow() : null);
             confirmation.setTitle("Delete Study Goal");
-            confirmation.setHeaderText("Are you sure you want to delete this study goal?");
-            confirmation.setContentText("Goal: " + goal.getDescription());
-            
+            confirmation.setHeaderText("Permanently delete this study goal?");
+            confirmation.setContentText("This cannot be undone.\nGoal: " + goal.getDescription());
+
             confirmation.showAndWait().ifPresent(response -> {
                 if (response == ButtonType.OK) {
                     studyService.deleteStudyGoal(goal.getId());
@@ -1085,10 +1125,10 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
                 }
             });
         });
-        
+
         actionBox.getChildren().add(deleteBtn);
         goalBox.getChildren().add(actionBox);
-        
+
         return goalBox;
     }
     

--- a/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
@@ -545,15 +545,15 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
                     .filter(g -> g.getDate().isAfter(dateTimeService.getCurrentDate().minusDays(30)))
                     .collect(Collectors.toList());
             List<Task> allTasks = taskService.getTasks();
-            
+
             // Calculate statistics
             int totalSessions = recentSessions.size();
             int totalMinutes = recentSessions.stream().mapToInt(StudySession::getDurationMinutes).sum();
             int totalPoints = recentSessions.stream().mapToInt(StudySession::getPointsEarned).sum();
-            
-            double avgFocus = recentSessions.isEmpty() ? 0 : 
+
+            double avgFocus = recentSessions.isEmpty() ? 0 :
                 recentSessions.stream().mapToInt(StudySession::getFocusLevel).average().orElse(0);
-            
+
             int achievedGoals = (int) recentGoals.stream().filter(StudyGoal::isAchieved).count();
             int totalGoals = recentGoals.size();
             double goalCompletionRate = totalGoals > 0 ? (double) achievedGoals / totalGoals * 100 : 0;
@@ -765,7 +765,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         double avgMinutesPerDay = totalMinutes / 30.0;
         double volumeScore = Math.min(1.0, avgMinutesPerDay / 120.0) * 20; // 2 hours per day = max score
         
-        // Goal achievement score (10% weight)
+        // Goal achievement score (10% weight) — failed/delayed goals count against the rate
         List<StudyGoal> goals = studyService.getStudyGoals().stream()
             .filter(g -> g.getDate().isAfter(dateTimeService.getCurrentDate().minusDays(30)))
             .collect(Collectors.toList());

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -1,6 +1,7 @@
 
 package com.studysync.presentation.ui.components;
 
+import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.entity.Task;
 import com.studysync.domain.entity.TaskReminder;
 import com.studysync.domain.valueobject.TaskCategory;
@@ -198,7 +199,10 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         return sp;
     }
 
-    private HBox buildTaskCard(Task task) {
+    private VBox buildTaskCard(Task task) {
+        VBox wrapper = new VBox(0);
+        wrapper.setMaxWidth(Double.MAX_VALUE);
+
         HBox card = new HBox(15);
         card.setPadding(new Insets(14));
         card.setAlignment(Pos.CENTER_LEFT);
@@ -206,8 +210,8 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
         String bgColor = TaskStyleUtils.statusBackground(task.getStatus());
         String borderColor = TaskStyleUtils.taskBorderColor(task.getStatus());
-        card.setStyle("-fx-background-color: " + bgColor + "; -fx-background-radius: 8;" +
-                      " -fx-border-color: " + borderColor + "; -fx-border-radius: 8;" +
+        card.setStyle("-fx-background-color: " + bgColor + "; -fx-background-radius: 8 8 0 0;" +
+                      " -fx-border-color: " + borderColor + "; -fx-border-radius: 8 8 0 0;" +
                       " -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.07), 4, 0, 0, 1);");
 
         // Left: Status indicator bar
@@ -348,8 +352,145 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
             info.getChildren().addAll(titleRow, metaRow, desc);
         }
 
+        // Goal History toggle button
+        VBox goalHistoryPane = new VBox(6);
+        goalHistoryPane.setPadding(new Insets(10, 14, 14, 14));
+        goalHistoryPane.setStyle("-fx-background-color: #f8f9fa; -fx-border-color: " + borderColor +
+                                 "; -fx-border-width: 0 1 1 1; -fx-background-radius: 0 0 8 8;" +
+                                 " -fx-border-radius: 0 0 8 8;");
+        goalHistoryPane.setVisible(false);
+        goalHistoryPane.setManaged(false);
+
+        Button goalHistoryBtn = new Button("Goal History");
+        goalHistoryBtn.getStyleClass().addAll("btn-small");
+        goalHistoryBtn.setStyle("-fx-font-size: 11px; -fx-padding: 3 10; -fx-background-color: #e8eaf6;" +
+                                " -fx-background-radius: 4; -fx-text-fill: #3949ab; -fx-cursor: hand;");
+        goalHistoryBtn.setOnAction(e -> {
+            boolean showing = goalHistoryPane.isVisible();
+            if (!showing) {
+                populateGoalHistory(goalHistoryPane, task);
+                card.setStyle("-fx-background-color: " + bgColor + "; -fx-background-radius: 8 8 0 0;" +
+                              " -fx-border-color: " + borderColor + "; -fx-border-radius: 8 8 0 0;" +
+                              " -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.07), 4, 0, 0, 1);");
+            } else {
+                card.setStyle("-fx-background-color: " + bgColor + "; -fx-background-radius: 8;" +
+                              " -fx-border-color: " + borderColor + "; -fx-border-radius: 8;" +
+                              " -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.07), 4, 0, 0, 1);");
+            }
+            goalHistoryPane.setVisible(!showing);
+            goalHistoryPane.setManaged(!showing);
+            goalHistoryBtn.setText(showing ? "Goal History" : "Hide Goals");
+        });
+        info.getChildren().add(goalHistoryBtn);
+
         card.getChildren().addAll(colorBar, info);
-        return card;
+        wrapper.getChildren().addAll(card, goalHistoryPane);
+        return wrapper;
+    }
+
+    private void populateGoalHistory(VBox pane, Task task) {
+        pane.getChildren().clear();
+
+        List<StudyGoal> goals = StudyGoal.findByTaskId(task.getId());
+
+        if (goals.isEmpty()) {
+            Label empty = new Label("No goals have been planned for this task yet.");
+            TaskStyleUtils.fontNormal(empty, 12);
+            empty.setTextFill(Color.web("#7f8c8d"));
+            pane.getChildren().add(empty);
+            return;
+        }
+
+        // Summary stats
+        long achieved = goals.stream().filter(StudyGoal::isAchieved).count();
+        long failed = goals.stream().filter(StudyGoal::isFailed).count();
+        long active = goals.stream().filter(g -> !g.isAchieved() && !g.isFailed()).count();
+
+        Label statsLabel = new Label("Total: " + goals.size()
+                + "  |  Achieved: " + achieved
+                + "  |  Failed: " + failed
+                + "  |  Active: " + active);
+        TaskStyleUtils.fontSemiBold(statsLabel, 11);
+        statsLabel.setTextFill(Color.web("#495057"));
+        statsLabel.setPadding(new Insets(0, 0, 4, 0));
+        pane.getChildren().add(statsLabel);
+
+        // Goal list
+        for (StudyGoal goal : goals) {
+            HBox row = new HBox(8);
+            row.setAlignment(Pos.CENTER_LEFT);
+            row.setPadding(new Insets(4, 8, 4, 8));
+
+            // Status indicator
+            String statusIcon;
+            String statusColor;
+            if (goal.isAchieved()) {
+                statusIcon = "\u2713"; // checkmark
+                statusColor = "#27ae60";
+            } else if (goal.isFailed()) {
+                statusIcon = "\u2715"; // X
+                statusColor = "#e74c3c";
+            } else if (goal.isDelayed()) {
+                statusIcon = "\u231B"; // hourglass
+                statusColor = "#f39c12";
+            } else {
+                statusIcon = "\u25CB"; // circle
+                statusColor = "#3498db";
+            }
+
+            Label icon = TaskStyleUtils.iconLabel(statusIcon, 11);
+            icon.setTextFill(Color.web(statusColor));
+
+            // Date
+            Label dateLabel = new Label(goal.getDate().toString());
+            TaskStyleUtils.fontNormal(dateLabel, 11);
+            dateLabel.setTextFill(Color.web("#6c757d"));
+            dateLabel.setMinWidth(80);
+
+            // Description
+            String descText = goal.getDescription() != null ? goal.getDescription() : "";
+            if (descText.length() > 80) descText = descText.substring(0, 80) + "...";
+            Label descLabel = new Label(descText);
+            TaskStyleUtils.fontNormal(descLabel, 11);
+            descLabel.setWrapText(true);
+            HBox.setHgrow(descLabel, Priority.ALWAYS);
+            if (goal.isFailed()) {
+                descLabel.setTextFill(Color.web("#999"));
+            } else if (goal.isAchieved()) {
+                descLabel.setTextFill(Color.web("#2d6a4f"));
+            } else {
+                descLabel.setTextFill(Color.web("#333"));
+            }
+
+            // Status badge
+            Label badge;
+            if (goal.isAchieved()) {
+                badge = new Label("Achieved");
+                badge.setStyle("-fx-background-color: #e8f5e9; -fx-background-radius: 8; -fx-padding: 1 6;");
+                badge.setTextFill(Color.web("#1b5e20"));
+            } else if (goal.isFailed()) {
+                badge = new Label("Failed");
+                badge.setStyle("-fx-background-color: #ffebee; -fx-background-radius: 8; -fx-padding: 1 6;");
+                badge.setTextFill(Color.web("#b71c1c"));
+            } else if (goal.isDelayed()) {
+                badge = new Label("Delayed (" + goal.getDaysDelayed() + "d)");
+                badge.setStyle("-fx-background-color: #fff3e0; -fx-background-radius: 8; -fx-padding: 1 6;");
+                badge.setTextFill(Color.web("#e65100"));
+            } else {
+                badge = new Label("Active");
+                badge.setStyle("-fx-background-color: #e3f2fd; -fx-background-radius: 8; -fx-padding: 1 6;");
+                badge.setTextFill(Color.web("#0d47a1"));
+            }
+            TaskStyleUtils.fontBold(badge, 10);
+
+            row.getChildren().addAll(icon, dateLabel, descLabel, badge);
+
+            // Alternate row background
+            row.setStyle("-fx-background-color: " + (pane.getChildren().size() % 2 == 0 ? "#f0f0f0" : "transparent") +
+                         "; -fx-background-radius: 4;");
+
+            pane.getChildren().add(row);
+        }
     }
 
     // ──────────────────────────────────────────────

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -179,3 +179,7 @@ ALTER TABLE tasks ADD COLUMN IF NOT EXISTS start_date DATE;
 -- Add replanned_for_date to study_goals to support one-shot manual rescheduling.
 -- When set, the goal appears on that date only and is excluded from automatic delay carry-forward.
 ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS replanned_for_date DATE;
+
+-- Add failed flag to study_goals. Failed goals are kept for historical logging
+-- but excluded from active planner views.
+ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS failed BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- **Goal History section** in Task Management: each task card has a toggleable "Goal History" pane showing all goals ever linked to that task (achieved, active, delayed, failed) with summary stats
- **Goals are never auto-deleted**: overdue goals (14+ days) are now marked as `FAILED` instead of physically removed from the database
- **Calendar shows all goal statuses**: failed, achieved, delayed, and pending goals all appear on the calendar for their planned date with distinct visual styling
- **Calendar delete is permanent**: "Delete" on the calendar hard-deletes the goal from the database; a separate "Mark as Failed" button does soft-deletion
- **Re-planned goals marked as failed**: goals re-planned to a date that passes without achievement are marked as failed (not silently dropped)
- **Active views filter out failed goals**: planner and re-plan dropdown exclude failed goals so they don't clutter daily workflow

## Changes
- `schema.sql`: new `failed BOOLEAN DEFAULT FALSE` column on `study_goals`
- `StudyGoal.java`: `failed` field, updated constructors/save/rowMapper, new `findByTaskId()` query, `findAllByDate()`/`findAllByDateIncludingDelayed()` for calendar, all planner queries filter `failed = FALSE`
- `StudyService.java`: `processAllDelayedGoals()` marks as FAILED instead of deleting; `deleteStudyGoal()` does hard delete; `markGoalAsFailed()` does soft-delete; re-planned goals marked failed when replan date passes
- `CalendarViewPanel.java`: shows all goal statuses with styling, "Mark as Failed" button, hard delete
- `TaskManagementPanel.java`: expandable goal history pane per task card with status icons and badges
- `ProfileViewPanel.java`: failed/delayed goals count against goal completion rate
- `StudySyncUI.java`: updated log message for renamed record field

## Test plan
- [x] Verify goals overdue by 14+ days get marked FAILED on startup (not deleted)
- [x] Verify failed goals don't appear in the daily planner or re-plan dropdown
- [x] Verify "Goal History" button on task cards shows all goals (including failed)
- [x] Verify deleting a goal from calendar permanently removes it from DB
- [x] Verify "Mark as Failed" on calendar soft-deletes (goal stays visible as failed)
- [x] Verify calendar shows failed goals with red styling on their planned date
- [x] Verify re-planned goals that pass their replan date get marked as failed
- [x] Verify new goals created for a task appear in goal history immediately

Generated with Claude Code