### PR TITLE
Fix study session persistence and add recovery tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ studysync.desktop
 # Temporary files
 *.tmp
 *.bak
+.codex
 
 # Incomplete scripts
 install-desktop-entry.sh

--- a/src/main/java/com/studysync/domain/entity/StudySession.java
+++ b/src/main/java/com/studysync/domain/entity/StudySession.java
@@ -1,10 +1,8 @@
 
 package com.studysync.domain.entity;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,14 +117,22 @@ public class StudySession {
             throw new IllegalStateException("JdbcTemplate not initialized. Make sure Spring context is loaded.");
         }
         
-        String sql = "MERGE INTO study_sessions (id, date, start_time, end_time, duration_minutes, completed, focus_level, confidence_level, notes, subject, topic, location, outcome_expected, actual_work, what_helped, what_distracted, improvement_note, points_earned, session_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        String sql = """
+            MERGE INTO study_sessions (id, date, start_time, end_time, duration_minutes, completed,
+                                      focus_level, confidence_level, notes, subject, topic, location,
+                                      outcome_expected, actual_work, what_helped, what_distracted,
+                                      improvement_note, points_earned, session_text, is_active,
+                                      last_update_time, current_elapsed_minutes, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """;
         jdbcTemplate.update(sql,
             this.id, this.date, this.startTime, this.endTime,
             this.durationMinutes, this.completed, this.focusLevel,
             this.confidenceLevel, this.notes, this.subject,
             this.topic, this.location, this.outcomeExpected,
             this.actualWork, this.whatHelped, this.whatDistracted,
-            this.improvementNote, this.pointsEarned, this.sessionText
+            this.improvementNote, this.pointsEarned, this.sessionText,
+            this.isActive, this.lastUpdateTime, this.currentElapsedMinutes
         );
         
         logger.debug("Study session saved: {}", this.id);
@@ -275,6 +281,9 @@ public class StudySession {
                 rs.getInt("points_earned"),
                 rs.getString("session_text")
             );
+            session.setActive(rs.getBoolean("is_active"));
+            session.setLastUpdateTime(rs.getObject("last_update_time", LocalDateTime.class));
+            session.setCurrentElapsedMinutes(rs.getInt("current_elapsed_minutes"));
             return session;
         };
     }
@@ -282,6 +291,7 @@ public class StudySession {
     // Business logic methods
     public void startSession() {
         this.startTime = LocalDateTime.now();
+        this.date = this.startTime.toLocalDate();
         this.isActive = true;
         this.lastUpdateTime = LocalDateTime.now();
         this.currentElapsedMinutes = 0;
@@ -495,6 +505,10 @@ public class StudySession {
 
     public LocalDateTime getLastUpdateTime() { return lastUpdateTime; }
     public void setLastUpdateTime(LocalDateTime lastUpdateTime) { this.lastUpdateTime = lastUpdateTime; }
+
+    public void setCurrentElapsedMinutes(int currentElapsedMinutes) {
+        this.currentElapsedMinutes = currentElapsedMinutes;
+    }
 
 
     @Override

--- a/src/main/java/com/studysync/domain/entity/StudySession.java
+++ b/src/main/java/com/studysync/domain/entity/StudySession.java
@@ -208,6 +208,28 @@ public class StudySession {
             return Optional.empty();
         }
     }
+
+    /**
+     * Returns the most recently started active session across all dates.
+     */
+    public static Optional<StudySession> findActiveSession() {
+        if (jdbcTemplate == null) {
+            throw new IllegalStateException("JdbcTemplate not initialized");
+        }
+
+        String sql = """
+                SELECT * FROM study_sessions
+                WHERE completed = FALSE AND is_active = TRUE
+                ORDER BY start_time DESC
+                LIMIT 1
+                """;
+        try {
+            StudySession session = jdbcTemplate.queryForObject(sql, getRowMapper());
+            return Optional.ofNullable(session);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
     
     /**
      * Get sessions in date range.

--- a/src/main/java/com/studysync/domain/service/ProjectService.java
+++ b/src/main/java/com/studysync/domain/service/ProjectService.java
@@ -5,6 +5,8 @@ import com.studysync.domain.entity.ProjectSession;
 import com.studysync.domain.valueobject.ProjectStatus;
 import com.studysync.domain.service.ProjectSessionEnd;
 import com.studysync.integration.drive.GoogleDriveService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,8 @@ import java.util.stream.Collectors;
 @Transactional
 public class ProjectService {
 
+    private static final Logger logger = LoggerFactory.getLogger(ProjectService.class);
+
     private final GoogleDriveService googleDriveService;
 
     @Autowired
@@ -43,6 +47,25 @@ public class ProjectService {
             });
         } else {
             googleDriveService.markLocalDbDirty();
+        }
+    }
+
+    private void markDirtyAndSaveLocally(String operation) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    googleDriveService.markLocalDbDirty();
+                    if (!googleDriveService.saveLocally()) {
+                        logger.warn("Local checkpoint failed after {}", operation);
+                    }
+                }
+            });
+        } else {
+            googleDriveService.markLocalDbDirty();
+            if (!googleDriveService.saveLocally()) {
+                logger.warn("Local checkpoint failed after {}", operation);
+            }
         }
     }
 
@@ -69,7 +92,7 @@ public class ProjectService {
             throw new IllegalArgumentException("Project title cannot be empty");
         }
         project.save();
-        markDirty();
+        markDirtyAndSaveLocally("project creation");
     }
 
     public void updateProject(Project project) {
@@ -77,7 +100,7 @@ public class ProjectService {
             throw new IllegalArgumentException("Project cannot be null");
         }
         project.save();
-        markDirty();
+        markDirtyAndSaveLocally("project update");
     }
 
     public void deleteProject(String projectId) {
@@ -85,7 +108,7 @@ public class ProjectService {
         ProjectSession.deleteByProjectId(projectId);
         // Then delete the project
         Project.deleteById(projectId);
-        markDirty();
+        markDirtyAndSaveLocally("project deletion");
     }
 
     @Transactional(readOnly = true)
@@ -114,7 +137,7 @@ public class ProjectService {
         ProjectSession session = new ProjectSession(projectId);
         session.setStartTime(LocalDateTime.now());
         session.save();  // Model handles its own persistence
-        markDirty();
+        markDirtyAndSaveLocally("project session start");
         return session;
     }
 
@@ -143,7 +166,7 @@ public class ProjectService {
         project.addWorkedMinutes(existingSession.getDurationMinutes());
         project.incrementSessionCount();
         project.save();
-        markDirty();
+        markDirtyAndSaveLocally("project session completion");
     }
 
     public void deleteProjectSession(String sessionId) {
@@ -159,7 +182,7 @@ public class ProjectService {
 
         // Delete the session
         ProjectSession.deleteById(sessionId);
-        markDirty();
+        markDirtyAndSaveLocally("project session deletion");
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -389,6 +389,11 @@ public class StudyService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<StudySession> getActiveSession() {
+        return StudySession.findActiveSession();
+    }
+
+    @Transactional(readOnly = true)
     public List<StudySession> getSessionsInDateRange(LocalDate startDate, LocalDate endDate) {
         return StudySession.findInDateRange(startDate, endDate);
     }

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -71,6 +71,25 @@ public class StudyService {
         }
     }
 
+    private void markDirtyAndSaveLocally(String operation) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    googleDriveService.markLocalDbDirty();
+                    if (!googleDriveService.saveLocally()) {
+                        logger.warn("Local checkpoint failed after {}", operation);
+                    }
+                }
+            });
+        } else {
+            googleDriveService.markLocalDbDirty();
+            if (!googleDriveService.saveLocally()) {
+                logger.warn("Local checkpoint failed after {}", operation);
+            }
+        }
+    }
+
     @Transactional(readOnly = true)
     public List<StudySession> getStudySessions() {
         return StudySession.findAll();
@@ -246,7 +265,7 @@ public class StudyService {
             goal.setAchieved(achieved);
             goal.setReasonIfNotAchieved(reasonIfNot);
             goal.save();
-            markDirty();
+            markDirtyAndSaveLocally("study goal achievement update");
         }
     }
 
@@ -293,8 +312,9 @@ public class StudyService {
     public StudySession startStudySession() {
         StudySession session = new StudySession();
         session.startSession();
-        session.save();  // Model handles its own persistence
-        markDirty();
+        session.save();
+        markDirtyAndSaveLocally("study session start");
+        logger.info("Started study session {} at {}", session.getId(), session.getStartTime());
         return session;
     }
 
@@ -308,7 +328,9 @@ public class StudyService {
         
         // Save to database
         session.save();
-        markDirty();
+        markDirtyAndSaveLocally("study session completion");
+        logger.info("Completed study session {} on {} for {} minutes (focus={})",
+                session.getId(), session.getDate(), session.getDurationMinutes(), session.getFocusLevel());
     }
 
     public void addDailyReflection(DailyReflection reflection) {
@@ -357,7 +379,7 @@ public class StudyService {
     public void deleteStudySession(String sessionId) {
         boolean deleted = StudySession.deleteById(sessionId);
         if (deleted) {
-            markDirty();
+            markDirtyAndSaveLocally("study session deletion");
         }
     }
 

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -206,7 +206,7 @@ public class StudyService {
             });
         }
 
-        markDirty();
+        markDirtyAndSaveLocally("study goal creation");
     }
 
     /**
@@ -253,7 +253,7 @@ public class StudyService {
             }
             goal.setReplannedForDate(dateTimeService.getCurrentDate());
             goal.save();
-            markDirty();
+            markDirtyAndSaveLocally("study goal replan");
             logger.info("Rescheduled goal '{}' to appear today ({})", goal.getDescription(), dateTimeService.getCurrentDate());
         });
     }
@@ -283,7 +283,7 @@ public class StudyService {
             goal.setFailed(true);
             goal.setAchieved(false);
             goal.save();
-            markDirty();
+            markDirtyAndSaveLocally("study goal failure update");
             logger.info("Marked study goal '{}' as failed", goalId);
             return true;
         } else {
@@ -301,7 +301,7 @@ public class StudyService {
         }
         boolean deleted = StudyGoal.deleteById(goalId);
         if (deleted) {
-            markDirty();
+            markDirtyAndSaveLocally("study goal deletion");
             logger.info("Permanently deleted study goal '{}'", goalId);
         } else {
             logger.warn("Requested deletion for study goal '{}' but it did not exist", goalId);
@@ -335,7 +335,7 @@ public class StudyService {
 
     public void addDailyReflection(DailyReflection reflection) {
         reflection.save();
-        markDirty();
+        markDirtyAndSaveLocally("daily reflection save");
     }
 
     @Transactional(readOnly = true)
@@ -356,7 +356,7 @@ public class StudyService {
     public void deleteDailyReflection(LocalDate date) {
         boolean deleted = DailyReflection.deleteByDate(date);
         if (deleted) {
-            markDirty();
+            markDirtyAndSaveLocally("daily reflection deletion");
         }
     }
 
@@ -493,7 +493,7 @@ public class StudyService {
         }
 
         if (updatedGoals > 0 || failedGoals > 0) {
-            markDirty();
+            markDirtyAndSaveLocally("delayed goal processing");
         }
 
         return new GoalDelayProcessingResult(updatedGoals, failedGoals);

--- a/src/main/java/com/studysync/domain/service/TaskService.java
+++ b/src/main/java/com/studysync/domain/service/TaskService.java
@@ -82,6 +82,25 @@ public class TaskService {
             googleDriveService.markLocalDbDirty();
         }
     }
+
+    private void markDirtyAndSaveLocally(String operation) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    googleDriveService.markLocalDbDirty();
+                    if (!googleDriveService.saveLocally()) {
+                        logger.warn("Local checkpoint failed after {}", operation);
+                    }
+                }
+            });
+        } else {
+            googleDriveService.markLocalDbDirty();
+            if (!googleDriveService.saveLocally()) {
+                logger.warn("Local checkpoint failed after {}", operation);
+            }
+        }
+    }
     
     @Transactional(readOnly = true)
     public List<Task> getTasks() {
@@ -112,7 +131,7 @@ public class TaskService {
         
         logger.info("Successfully added task '{}' with priority {} and status {}", 
                    savedTask.getTitle(), savedTask.getPriority().stars(), savedTask.getStatus());
-        markDirty();
+        markDirtyAndSaveLocally("task creation");
         return savedTask;
     }
     
@@ -131,7 +150,7 @@ public class TaskService {
         }
         
         logger.info("Removed task: {}", task.getTitle());
-        markDirty();
+        markDirtyAndSaveLocally("task deletion");
     }
     
     @Transactional
@@ -142,7 +161,7 @@ public class TaskService {
         
         Task savedTask = finalTask.save();
         logger.info("Updated task: {}", savedTask.getTitle());
-        markDirty();
+        markDirtyAndSaveLocally("task update");
         return savedTask;
     }
     
@@ -158,7 +177,7 @@ public class TaskService {
         }
         
         logger.info("Updated task status for '{}' to {}", task.getTitle(), newStatus);
-        markDirty();
+        markDirtyAndSaveLocally("task status update");
     }
     
     @Transactional(readOnly = true)
@@ -226,7 +245,7 @@ public class TaskService {
 
         if (updatedCount > 0) {
             logger.info("Marked {} tasks as DELAYED", updatedCount);
-            markDirty();
+            markDirtyAndSaveLocally("delayed task processing");
         }
 
         return updatedCount;
@@ -297,6 +316,9 @@ public class TaskService {
         
         int deletedCount = Task.deleteByIds(taskIds);
         logger.info("Batch deleted {} tasks", deletedCount);
+        if (deletedCount > 0) {
+            markDirtyAndSaveLocally("batch task deletion");
+        }
         return deletedCount;
     }
     

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
@@ -1,6 +1,7 @@
 package com.studysync.integration.drive;
 
 import com.google.api.client.auth.oauth2.Credential;
+import com.studysync.config.DatabaseReloadService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class GoogleDriveService {
     private final GoogleCredentialManager credentialManager;
     private final GoogleDriveGateway gateway;
     private final JdbcTemplate jdbcTemplate;
+    private final DatabaseReloadService databaseReloadService;
     private Credential activeCredential;
     private String cachedAccountEmail;
     private volatile boolean shutdownSaveEnabled = false;
@@ -44,11 +46,14 @@ public class GoogleDriveService {
     /** Listeners notified just before the database is shut down for a reload. */
     private final java.util.List<Runnable> preReloadListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
 
-    public GoogleDriveService(GoogleDriveSettings settings, GoogleCredentialManager credentialManager, GoogleDriveGateway gateway, JdbcTemplate jdbcTemplate) {
+    public GoogleDriveService(GoogleDriveSettings settings, GoogleCredentialManager credentialManager,
+                              GoogleDriveGateway gateway, JdbcTemplate jdbcTemplate,
+                              DatabaseReloadService databaseReloadService) {
         this.settings = settings;
         this.credentialManager = credentialManager;
         this.gateway = gateway;
         this.jdbcTemplate = jdbcTemplate;
+        this.databaseReloadService = databaseReloadService;
 
         if (settings != null && settings.isReady()) {
             this.activeCredential = loadStoredCredential();
@@ -363,6 +368,8 @@ public class GoogleDriveService {
 
     @PreDestroy
     public void onShutdown() {
+        boolean shutdownOk = shutdownDatabaseEngine();
+
         // Upload to Drive if explicitly requested (dialog "Push to Drive & Exit")
         // OR if the user never went through the exit dialog at all (SIGTERM, OS
         // logout, etc.) and there are unsaved local changes.  This prevents
@@ -371,36 +378,24 @@ public class GoogleDriveService {
         // shutdownSaveEnabled=false).
         boolean shouldUpload = shutdownSaveEnabled || (localDbDirty && !shutdownSaveExplicitlyDisabled);
         if (isIntegrationEnabled() && activeCredential != null && shouldUpload) {
-            boolean checkpointOk = false;
-            try {
-                jdbcTemplate.execute("CHECKPOINT SYNC");
-                checkpointOk = true;
-                logger.info("H2 checkpoint completed before Drive upload");
-            } catch (Exception e) {
-                logger.warn("H2 CHECKPOINT SYNC failed before upload: {}", e.getMessage());
-            }
-            if (checkpointOk) {
-                logger.info("Uploading StudySync database to Google Drive before shutdown");
+            if (shutdownOk) {
+                logger.info("Uploading StudySync database to Google Drive after H2 shutdown");
                 gateway.uploadDatabaseToDrive(activeCredential);
             } else {
-                logger.warn("Skipping shutdown upload — checkpoint failed");
+                logger.warn("Skipping shutdown upload — database shutdown failed");
             }
         }
+    }
 
-        // Explicitly SHUTDOWN the H2 engine.  This flushes ALL committed data
-        // to the .mv.db file and destroys the engine, preventing H2's JVM
-        // shutdown hook from later overwriting the file with stale MVStore
-        // page data.  Without this, DB_CLOSE_DELAY=-1 keeps the engine alive
-        // after HikariPool closes, and the shutdown hook's engine close can
-        // write an older MVStore version — silently reverting changes made
-        // since the last auto-save (including downloaded Drive data).
+    private boolean shutdownDatabaseEngine() {
         try {
-            jdbcTemplate.execute("SHUTDOWN");
+            databaseReloadService.shutdown();
+            logger.info("H2 engine shut down — all data flushed to disk");
+            return true;
         } catch (Exception e) {
-            // Expected: H2 kills the executing connection during SHUTDOWN
-            logger.debug("H2 SHUTDOWN completed (exception expected): {}", e.getMessage());
+            logger.warn("H2 shutdown failed during application shutdown", e);
+            return false;
         }
-        logger.info("H2 engine shut down — all data flushed to disk");
     }
 
     private Credential loadStoredCredential() {

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
@@ -146,7 +146,7 @@ public class GoogleDriveService {
     public boolean saveLocally() {
         try {
             jdbcTemplate.execute("CHECKPOINT SYNC");
-            logger.info("Local save completed — database flushed to disk");
+            logger.info("Local save completed — checkpoint sync finished successfully");
             return true;
         } catch (Exception e) {
             logger.error("Local save failed (CHECKPOINT SYNC): {}", e.getMessage());
@@ -158,20 +158,38 @@ public class GoogleDriveService {
         if (!isIntegrationEnabled() || activeCredential == null) {
             return false;
         }
-        // Flush H2 in-memory cache to the .mv.db file before uploading.
-        // If the checkpoint fails, abort the upload to avoid overwriting
-        // Drive with a stale database file that is missing recent writes.
+
+        notifyPreReloadListeners();
+
         try {
-            jdbcTemplate.execute("CHECKPOINT SYNC");
+            databaseReloadService.shutdown();
+            logger.info("H2 engine shut down before manual Drive upload");
         } catch (Exception e) {
-            logger.error("H2 CHECKPOINT SYNC failed before upload — aborting upload to prevent stale data on Drive", e);
+            logger.error("DB shutdown failed before manual Drive upload — aborting upload", e);
+            notifyReloadListeners();
             return false;
         }
-        boolean uploaded = gateway.uploadDatabaseToDrive(activeCredential);
-        if (uploaded) {
-            localDbDirty = false;
+
+        boolean uploaded = false;
+        boolean reconnectOk = false;
+        try {
+            logger.info("Uploading StudySync database to Google Drive after H2 shutdown");
+            uploaded = gateway.uploadDatabaseToDrive(activeCredential);
+            if (uploaded) {
+                localDbDirty = false;
+            }
+        } finally {
+            try {
+                databaseReloadService.reconnect();
+                reconnectOk = true;
+                logger.info("Database reconnected after manual Drive upload");
+            } catch (Exception e) {
+                logger.error("DB reconnect failed after manual Drive upload — application may need a restart", e);
+            } finally {
+                notifyReloadListeners();
+            }
         }
-        return uploaded;
+        return uploaded && reconnectOk;
     }
 
     public synchronized boolean downloadDatabaseSnapshot() {

--- a/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
+++ b/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
@@ -58,6 +58,8 @@ public class StudySyncUI {
     private final Map<Tab, RefreshablePanel> panelMap;
     private TabPane tabPane;
     private StackPane overlayLayer;
+    private Stage profileStage;
+    private ProfileViewPanel profilePanel;
 
     @Autowired
     public StudySyncUI(TaskService taskService, CategoryService categoryService, ReminderService reminderService,
@@ -193,8 +195,16 @@ public class StudySyncUI {
             markDelayedTasksOnStartup();
             processDelayedGoalsOnStartup();
 
-            hideReloadOverlay();
             refreshAllPanels();
+            // Some controls still need one more JavaFX pulse after a live DB
+            // reload before they fully reflect the replacement database.
+            Platform.runLater(() -> {
+                refreshAllPanels();
+                if (profilePanel != null) {
+                    profilePanel.updateDisplay();
+                }
+                hideReloadOverlay();
+            });
         }));
         
         // Initialize the default tab after showing the window (to ensure Spring context is fully loaded)
@@ -357,13 +367,20 @@ public class StudySyncUI {
     }
     
     private void showProfileWindow() {
+        if (profileStage != null && profileStage.isShowing()) {
+            profilePanel.updateDisplay();
+            profileStage.toFront();
+            profileStage.requestFocus();
+            return;
+        }
+
         // Create a new stage for the profile window
-        Stage profileStage = new Stage();
+        profileStage = new Stage();
         profileStage.setTitle("Study Profile & Analytics");
         profileStage.initOwner(tabPane.getScene().getWindow());
         
         // Create the profile panel
-        ProfileViewPanel profilePanel = new ProfileViewPanel(studyService, projectService, taskService, dateTimeService, googleDriveService, databaseReloadService::shutdown, databaseReloadService::reconnect);
+        profilePanel = new ProfileViewPanel(studyService, projectService, taskService, dateTimeService, googleDriveService, databaseReloadService::shutdown, databaseReloadService::reconnect);
         
         Scene profileScene = new Scene(profilePanel, 1000, 700);
         profileScene.getStylesheets().add(getClass().getResource("/styles.css").toExternalForm());
@@ -373,6 +390,10 @@ public class StudySyncUI {
         profileStage.setMinHeight(600);
         profileStage.setWidth(1000);
         profileStage.setHeight(700);
+        profileStage.setOnHidden(event -> {
+            profileStage = null;
+            profilePanel = null;
+        });
         profileStage.show();
         
         // Update the profile display

--- a/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
@@ -240,6 +240,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
                     driveActionStatusLabel.setText(failureMessage);
                 } else if (Boolean.TRUE.equals(result)) {
                     driveActionStatusLabel.setText(successMessage);
+                    updateDisplay();
                 } else {
                     driveActionStatusLabel.setText(failureMessage);
                 }

--- a/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
@@ -179,7 +179,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         saveLocallyButton.setOnAction(e -> runDriveAction(
             "Saving database to disk…",
             () -> googleDriveService.saveLocally(),
-            "Saved! Database flushed to disk.",
+            "Saved! Local checkpoint completed.",
             "Save failed. Check logs for details."
         ));
 

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -1648,10 +1648,15 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             return;
         }
 
+        boolean sameActiveSession = currentSession != null
+                && currentSession.getId() != null
+                && currentSession.getId().equals(activeSession.getId());
         currentSession = activeSession;
-        String sessionText = activeSession.getSessionText() != null ? activeSession.getSessionText() : "";
-        if (!sessionText.equals(sessionTextArea.getText())) {
-            sessionTextArea.setText(sessionText);
+        if (!sameActiveSession) {
+            String sessionText = activeSession.getSessionText() != null ? activeSession.getSessionText() : "";
+            if (!sessionText.equals(sessionTextArea.getText())) {
+                sessionTextArea.setText(sessionText);
+            }
         }
         if (sessionTimer == null) {
             startSessionTimer();

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -78,6 +78,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     private Label dateNavLabel;
     private final Label dateNavIcon = TaskStyleUtils.iconLabel("\u25A6", 22);
     private TextArea sessionTextArea;
+    private Button startSessionBtn;
+    private Button endSessionBtn;
+    private Label sessionStatusLabel;
 
     // ──────────────────────────────────────────────
     // CONSTRUCTION
@@ -235,41 +238,32 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox sessionControls = new HBox(15);
         sessionControls.setAlignment(Pos.CENTER_LEFT);
 
-        Button startSessionBtn = new Button("Start Session");
+        startSessionBtn = new Button("Start Session");
         startSessionBtn.getStyleClass().add("btn-success");
 
-        Button endSessionBtn = new Button("End Session");
+        endSessionBtn = new Button("End Session");
         endSessionBtn.getStyleClass().add("btn-danger");
         endSessionBtn.setDisable(true);
 
-        Label sessionStatus = new Label("No active session");
-        TaskStyleUtils.fontNormal(sessionStatus, 14);
+        sessionStatusLabel = new Label("No active session");
+        TaskStyleUtils.fontNormal(sessionStatusLabel, 14);
 
         startSessionBtn.setOnAction(e -> {
             currentSession = studyService.startStudySession();
-            startSessionTimer(sessionStatus);
-            startSessionBtn.setDisable(true);
-            endSessionBtn.setDisable(false);
-            sessionTextArea.setDisable(false);
             sessionTextArea.clear();
+            startSessionTimer();
+            syncSessionControls();
+            updateSessionsDisplay();
         });
 
         endSessionBtn.setOnAction(e -> {
             if (currentSession != null) {
                 currentSession.setSessionText(sessionTextArea.getText());
-                stopSessionTimer();
                 showEndSessionDialog();
-                javafx.application.Platform.runLater(() -> {
-                    sessionStatus.setText("No active session");
-                    startSessionBtn.setDisable(false);
-                    endSessionBtn.setDisable(true);
-                    sessionTextArea.setDisable(true);
-                    updateSessionsDisplay();
-                });
             }
         });
 
-        sessionControls.getChildren().addAll(startSessionBtn, endSessionBtn, sessionStatus);
+        sessionControls.getChildren().addAll(startSessionBtn, endSessionBtn, sessionStatusLabel);
 
         sessionTextArea = new TextArea();
         sessionTextArea.setPromptText("Write your session notes, thoughts, or study content here…");
@@ -289,6 +283,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         sessionSection.getChildren().addAll(
                 sessionTitle, sessionControls, sessionTextArea, completedLabel, sessionsFlowPane);
         mainContent.getChildren().add(sessionSection);
+        syncSessionControls();
     }
 
     private void createReflectionSection(VBox mainContent) {
@@ -823,15 +818,23 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     private void updateSessionsDisplay() {
         sessionsFlowPane.getChildren().clear();
         List<StudySession> sessions = studyService.getSessionsForDate(displayDate);
+        List<StudySession> completedSessions = sessions.stream()
+                .filter(StudySession::isCompleted)
+                .toList();
+        List<StudySession> incompleteSessions = sessions.stream()
+                .filter(session -> !session.isCompleted())
+                .toList();
 
-        for (StudySession session : sessions) {
-            if (session.isCompleted()) {
-                sessionsFlowPane.getChildren().add(buildSessionCard(session));
-            }
+        for (StudySession session : completedSessions) {
+            sessionsFlowPane.getChildren().add(buildSessionCard(session));
+        }
+
+        for (StudySession session : incompleteSessions) {
+            sessionsFlowPane.getChildren().add(buildIncompleteSessionCard(session));
         }
 
         if (sessionsFlowPane.getChildren().isEmpty()) {
-            Label none = new Label("No completed sessions yet.");
+            Label none = new Label("No sessions for this date.");
             TaskStyleUtils.fontNormal(none, 13);
             none.setTextFill(Color.web("#7f8c8d"));
             sessionsFlowPane.getChildren().add(none);
@@ -900,6 +903,70 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         btnRow.getChildren().addAll(detailsBtn, deleteBtn);
         card.getChildren().addAll(timeLabel, durationLabel, focusLabel, pointsLabel, btnRow);
+        return card;
+    }
+
+    private VBox buildIncompleteSessionCard(StudySession session) {
+        VBox card = new VBox(5);
+        card.setPadding(new Insets(10, 12, 10, 12));
+        card.setPrefWidth(220);
+        card.setStyle("-fx-background-color: #fff8ef; -fx-background-radius: 8;" +
+                      " -fx-border-color: #f39c12; -fx-border-radius: 8;" +
+                      " -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.08), 4, 0, 0, 1);");
+
+        String startStr = session.getStartTime() != null
+                ? session.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")) : "?";
+        String endStr = session.getEndTime() != null
+                ? session.getEndTime().format(DateTimeFormatter.ofPattern("HH:mm")) : "?";
+
+        Label statusLabel = new Label(session.isActive() ? "Active, not completed" : "Incomplete session");
+        statusLabel.setGraphic(TaskStyleUtils.iconLabel(session.isActive() ? "\u23F3" : "\u26A0", 11));
+        TaskStyleUtils.fontBold(statusLabel, 11);
+        statusLabel.setTextFill(Color.web("#d35400"));
+
+        Label timeLabel = new Label(startStr + "\u2013" + endStr);
+        timeLabel.setGraphic(TaskStyleUtils.iconLabel("\u23F0", 12));
+        TaskStyleUtils.fontBold(timeLabel, 12);
+
+        String durationText = session.getDurationMinutes() > 0
+                ? session.getDurationMinutes() + " min tracked"
+                : "Not completed";
+        Label durationLabel = new Label(durationText);
+        TaskStyleUtils.fontNormal(durationLabel, 11);
+        durationLabel.setTextFill(Color.web("#7f8c8d"));
+
+        Button detailsBtn = new Button("Details");
+        detailsBtn.getStyleClass().addAll("btn-primary", "btn-small");
+        detailsBtn.setStyle("-fx-padding: 3 7;");
+        detailsBtn.setOnAction(e -> showSessionDetails(session));
+
+        Button deleteBtn = new Button("\u2715");
+        TaskStyleUtils.fontEmoji(deleteBtn, 11);
+        deleteBtn.getStyleClass().addAll("btn-danger", "btn-small");
+        deleteBtn.setStyle("-fx-padding: 3 7;");
+        deleteBtn.setOnAction(e -> {
+            Alert alert = new Alert(Alert.AlertType.CONFIRMATION,
+                    "Delete this incomplete session?", ButtonType.OK, ButtonType.CANCEL);
+            alert.setHeaderText(null);
+            alert.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
+            alert.showAndWait().ifPresent(bt -> {
+                if (bt == ButtonType.OK) {
+                    studyService.deleteStudySession(session.getId());
+                    if (currentSession != null && currentSession.getId().equals(session.getId())) {
+                        currentSession = null;
+                        stopSessionTimer();
+                        sessionTextArea.clear();
+                        syncSessionControls();
+                    }
+                    updateSessionsDisplay();
+                }
+            });
+        });
+
+        HBox btnRow = new HBox(5, detailsBtn, deleteBtn);
+        btnRow.setAlignment(Pos.CENTER_RIGHT);
+
+        card.getChildren().addAll(statusLabel, timeLabel, durationLabel, btnRow);
         return card;
     }
 
@@ -1266,13 +1333,19 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         okBtn.getStyleClass().add("btn-primary");
         Button cancelBtn = new Button("Cancel");
         cancelBtn.getStyleClass().add("btn-cancel");
-        cancelBtn.setOnAction(e -> closeModal.run());
+        cancelBtn.setOnAction(e -> {
+            closeModal.run();
+            syncSessionControls();
+        });
 
         okBtn.setOnAction(e -> {
             try {
                 StudySessionEnd sessionEnd = new StudySessionEnd((int) focusSlider.getValue(), notesArea.getText());
                 studyService.endStudySession(currentSession, sessionEnd);
+                stopSessionTimer();
                 currentSession = null;
+                sessionTextArea.clear();
+                syncSessionControls();
                 closeModal.run();
                 updateSessionsDisplay();
                 updateProgress();
@@ -1503,12 +1576,13 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         progressLabel.setText("Daily Progress: " + progress + "%");
     }
 
-    private void startSessionTimer(Label statusLabel) {
+    private void startSessionTimer() {
         if (sessionTimer != null) sessionTimer.stop();
         sessionTimer = new Timeline(new KeyFrame(Duration.seconds(1),
-                e -> updateSessionTimer(statusLabel)));
+                e -> updateSessionTimer()));
         sessionTimer.setCycleCount(Timeline.INDEFINITE);
         sessionTimer.play();
+        updateSessionTimer();
     }
 
     private void stopSessionTimer() {
@@ -1518,19 +1592,56 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         }
     }
 
-    private void updateSessionTimer(Label statusLabel) {
+    private void updateSessionTimer() {
+        if (sessionStatusLabel == null) {
+            return;
+        }
         if (currentSession != null && currentSession.isActive()) {
             currentSession.updateRealTimeProgress();
             int elapsed = currentSession.getCurrentElapsedMinutes();
             int h = elapsed / 60, m = elapsed % 60;
-            statusLabel.setText(h > 0
+            sessionStatusLabel.setText(h > 0
                     ? String.format("⌚ Session running: %dh %02dm", h, m)
                     : String.format("⌚ Session running: %dm", m));
-            statusLabel.setTextFill(Color.web("#27ae60"));
+            sessionStatusLabel.setTextFill(Color.web("#27ae60"));
         } else {
-            statusLabel.setText("No active session");
-            statusLabel.setTextFill(Color.web("#2c3e50"));
+            sessionStatusLabel.setText("No active session");
+            sessionStatusLabel.setTextFill(Color.web("#2c3e50"));
         }
+    }
+
+    private void syncSessionControls() {
+        if (startSessionBtn == null || endSessionBtn == null || sessionStatusLabel == null || sessionTextArea == null) {
+            return;
+        }
+
+        boolean hasActiveSession = currentSession != null && currentSession.isActive();
+        startSessionBtn.setDisable(hasActiveSession);
+        endSessionBtn.setDisable(!hasActiveSession);
+        sessionTextArea.setDisable(!hasActiveSession);
+
+        if (!hasActiveSession) {
+            updateSessionTimer();
+        }
+    }
+
+    private void restoreActiveSessionIfNeeded() {
+        if (currentSession != null || sessionTextArea == null) {
+            return;
+        }
+        if (!displayDate.equals(dateTimeService.getCurrentDate())) {
+            return;
+        }
+
+        studyService.getSessionsForDate(displayDate).stream()
+                .filter(session -> !session.isCompleted() && session.isActive())
+                .max(Comparator.comparing(StudySession::getStartTime,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .ifPresent(session -> {
+                    currentSession = session;
+                    sessionTextArea.setText(session.getSessionText() != null ? session.getSessionText() : "");
+                    startSessionTimer();
+                });
     }
 
     private void saveReflection() {
@@ -1574,6 +1685,8 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
     @Override
     public void updateDisplay() {
+        restoreActiveSessionIfNeeded();
+        syncSessionControls();
         boolean isToday = displayDate.equals(dateTimeService.getCurrentDate());
         String prefix = isToday ? "Today \u2014 " : "";
         dateNavLabel.setGraphic(dateNavIcon);

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -1626,22 +1626,36 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     }
 
     private void restoreActiveSessionIfNeeded() {
-        if (currentSession != null || sessionTextArea == null) {
+        if (sessionTextArea == null) {
             return;
         }
         if (!displayDate.equals(dateTimeService.getCurrentDate())) {
             return;
         }
 
-        studyService.getSessionsForDate(displayDate).stream()
+        StudySession activeSession = studyService.getSessionsForDate(displayDate).stream()
                 .filter(session -> !session.isCompleted() && session.isActive())
                 .max(Comparator.comparing(StudySession::getStartTime,
                         Comparator.nullsLast(Comparator.naturalOrder())))
-                .ifPresent(session -> {
-                    currentSession = session;
-                    sessionTextArea.setText(session.getSessionText() != null ? session.getSessionText() : "");
-                    startSessionTimer();
-                });
+                .orElse(null);
+
+        if (activeSession == null) {
+            if (currentSession != null) {
+                currentSession = null;
+                stopSessionTimer();
+                sessionTextArea.clear();
+            }
+            return;
+        }
+
+        currentSession = activeSession;
+        String sessionText = activeSession.getSessionText() != null ? activeSession.getSessionText() : "";
+        if (!sessionText.equals(sessionTextArea.getText())) {
+            sessionTextArea.setText(sessionText);
+        }
+        if (sessionTimer == null) {
+            startSessionTimer();
+        }
     }
 
     private void saveReflection() {

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -1633,11 +1633,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             return;
         }
 
-        StudySession activeSession = studyService.getSessionsForDate(displayDate).stream()
-                .filter(session -> !session.isCompleted() && session.isActive())
-                .max(Comparator.comparing(StudySession::getStartTime,
-                        Comparator.nullsLast(Comparator.naturalOrder())))
-                .orElse(null);
+        StudySession activeSession = studyService.getActiveSession().orElse(null);
 
         if (activeSession == null) {
             if (currentSession != null) {

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -1,0 +1,204 @@
+package com.studysync.domain.service;
+
+import com.studysync.domain.entity.StudyGoal;
+import com.studysync.domain.entity.StudySession;
+import com.studysync.integration.drive.GoogleDriveService;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StudyServicePersistenceTest {
+
+    private HikariDataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+    private GoogleDriveService googleDriveService;
+    private DateTimeService dateTimeService;
+    private StudyService studyService;
+
+    @BeforeEach
+    void setUp() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:studysync-persistence-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        config.setUsername("sa");
+        config.setPassword("");
+        config.setMaximumPoolSize(2);
+        config.setMinimumIdle(1);
+
+        dataSource = new HikariDataSource(config);
+        jdbcTemplate = new JdbcTemplate(dataSource);
+
+        createStudySessionsTable();
+        createStudyGoalsTable();
+
+        StudySession.setJdbcTemplate(jdbcTemplate);
+        StudyGoal.setJdbcTemplate(jdbcTemplate);
+
+        googleDriveService = mock(GoogleDriveService.class);
+        when(googleDriveService.saveLocally()).thenReturn(true);
+
+        dateTimeService = mock(DateTimeService.class);
+        when(dateTimeService.getCurrentDate()).thenReturn(LocalDate.of(2026, 3, 28));
+
+        studyService = new StudyService(googleDriveService, dateTimeService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        StudySession.setJdbcTemplate(null);
+        StudyGoal.setJdbcTemplate(null);
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void startStudySessionPersistsActiveSessionAndFlushesLocally() {
+        StudySession session = studyService.startStudySession();
+
+        assertTrue(session.isActive());
+        assertFalse(session.isCompleted());
+        assertNotNull(session.getStartTime());
+
+        Integer activeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_sessions WHERE id = ? AND completed = FALSE AND is_active = TRUE",
+                Integer.class,
+                session.getId());
+        assertEquals(1, activeCount);
+
+        verify(googleDriveService).markLocalDbDirty();
+        verify(googleDriveService).saveLocally();
+    }
+
+    @Test
+    void endStudySessionUpdatesExistingRowToCompletedAndFlushesLocally() {
+        StudySession session = studyService.startStudySession();
+        session.setSessionText("Recovered notes");
+
+        reset(googleDriveService);
+        when(googleDriveService.saveLocally()).thenReturn(true);
+
+        studyService.endStudySession(session, new StudySessionEnd(2, "Wrapped up chapter"));
+
+        StudySession stored = StudySession.findById(session.getId()).orElseThrow();
+        assertTrue(stored.isCompleted());
+        assertFalse(stored.isActive());
+        assertEquals(2, stored.getFocusLevel());
+        assertEquals("Wrapped up chapter", stored.getNotes());
+        assertEquals("Recovered notes", stored.getSessionText());
+        assertNotNull(stored.getEndTime());
+        assertTrue(stored.getDurationMinutes() >= 0);
+
+        verify(googleDriveService).markLocalDbDirty();
+        verify(googleDriveService).saveLocally();
+    }
+
+    @Test
+    void findByDateRestoresPersistedIncompleteSessionMetadata() {
+        LocalDate date = LocalDate.of(2026, 3, 27);
+        LocalDateTime lastUpdate = LocalDateTime.of(2026, 3, 27, 18, 45);
+
+        jdbcTemplate.update("""
+                INSERT INTO study_sessions (
+                    id, date, start_time, end_time, duration_minutes, completed, focus_level,
+                    confidence_level, notes, session_text, is_active, last_update_time,
+                    current_elapsed_minutes, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                "active-session", date, LocalDateTime.of(2026, 3, 27, 18, 0), null, 45, false,
+                3, 3, "In progress", "Partial notes", true, lastUpdate, 45);
+
+        List<StudySession> sessions = StudySession.findByDate(date);
+
+        assertEquals(1, sessions.size());
+        StudySession restored = sessions.getFirst();
+        assertFalse(restored.isCompleted());
+        assertTrue(restored.isActive());
+        assertEquals(lastUpdate, restored.getLastUpdateTime());
+        assertEquals("Partial notes", restored.getSessionText());
+    }
+
+    @Test
+    void updateStudyGoalAchievementFlushesCompletedGoalLocally() {
+        StudyGoal goal = new StudyGoal("Finish mock exam");
+        goal.setDate(LocalDate.of(2026, 3, 27));
+        goal.save();
+
+        reset(googleDriveService);
+        when(googleDriveService.saveLocally()).thenReturn(true);
+
+        studyService.updateStudyGoalAchievement(goal.getId(), true, null);
+
+        StudyGoal stored = StudyGoal.findById(goal.getId()).orElseThrow();
+        assertTrue(stored.isAchieved());
+
+        verify(googleDriveService).markLocalDbDirty();
+        verify(googleDriveService).saveLocally();
+    }
+
+    private void createStudySessionsTable() {
+        jdbcTemplate.execute("""
+                CREATE TABLE study_sessions (
+                    id VARCHAR(50) PRIMARY KEY,
+                    date DATE NOT NULL,
+                    start_time TIMESTAMP,
+                    end_time TIMESTAMP,
+                    duration_minutes INTEGER DEFAULT 0,
+                    completed BOOLEAN DEFAULT FALSE,
+                    focus_level INTEGER DEFAULT 3,
+                    confidence_level INTEGER DEFAULT 3,
+                    notes TEXT,
+                    subject VARCHAR(255),
+                    topic VARCHAR(255),
+                    location VARCHAR(255),
+                    outcome_expected TEXT,
+                    actual_work TEXT,
+                    what_helped TEXT,
+                    what_distracted TEXT,
+                    improvement_note TEXT,
+                    points_earned INTEGER DEFAULT 0,
+                    session_text TEXT,
+                    is_active BOOLEAN DEFAULT FALSE,
+                    last_update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    current_elapsed_minutes INTEGER DEFAULT 0,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+    }
+
+    private void createStudyGoalsTable() {
+        jdbcTemplate.execute("""
+                CREATE TABLE study_goals (
+                    id VARCHAR(50) PRIMARY KEY,
+                    date DATE NOT NULL,
+                    description TEXT NOT NULL,
+                    achieved BOOLEAN DEFAULT FALSE,
+                    reason_if_not_achieved TEXT,
+                    days_delayed INTEGER DEFAULT 0,
+                    is_delayed BOOLEAN DEFAULT FALSE,
+                    points_deducted INTEGER DEFAULT 0,
+                    task_id VARCHAR(50),
+                    replanned_for_date DATE,
+                    failed BOOLEAN DEFAULT FALSE,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+    }
+}

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -151,6 +151,31 @@ class StudyServicePersistenceTest {
         verify(googleDriveService).saveLocally();
     }
 
+    @Test
+    void getActiveSessionFindsSessionThatStartedPreviousDay() {
+        LocalDate sessionDate = LocalDate.of(2026, 3, 27);
+        LocalDateTime startTime = LocalDateTime.of(2026, 3, 27, 23, 50);
+        LocalDateTime lastUpdate = LocalDateTime.of(2026, 3, 28, 0, 10);
+
+        jdbcTemplate.update("""
+                INSERT INTO study_sessions (
+                    id, date, start_time, end_time, duration_minutes, completed, focus_level,
+                    confidence_level, notes, session_text, is_active, last_update_time,
+                    current_elapsed_minutes, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                "overnight-session", sessionDate, startTime, null, 20, false,
+                3, 3, "Still running", "Overnight notes", true, lastUpdate, 20);
+
+        StudySession restored = studyService.getActiveSession().orElseThrow();
+
+        assertEquals("overnight-session", restored.getId());
+        assertEquals(sessionDate, restored.getDate());
+        assertEquals(startTime, restored.getStartTime());
+        assertTrue(restored.isActive());
+        assertFalse(restored.isCompleted());
+    }
+
     private void createStudySessionsTable() {
         jdbcTemplate.execute("""
                 CREATE TABLE study_sessions (

--- a/src/test/java/com/studysync/integration/drive/GoogleDriveServiceTest.java
+++ b/src/test/java/com/studysync/integration/drive/GoogleDriveServiceTest.java
@@ -1,0 +1,83 @@
+package com.studysync.integration.drive;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.studysync.config.DatabaseReloadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GoogleDriveServiceTest {
+
+    private GoogleDriveService googleDriveService;
+    private GoogleDriveGateway gateway;
+    private DatabaseReloadService databaseReloadService;
+    private Credential activeCredential;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        GoogleDriveSettings settings = new GoogleDriveSettings(
+                true,
+                "client-id",
+                "client-secret",
+                8888,
+                "StudySync",
+                "StudySync",
+                "studysync.mv.db",
+                Path.of("build", "tmp", "test-drive", "studysync.mv.db"),
+                Path.of("build", "tmp", "test-drive", "credentials"));
+        GoogleCredentialManager credentialManager = mock(GoogleCredentialManager.class);
+        gateway = mock(GoogleDriveGateway.class);
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        databaseReloadService = mock(DatabaseReloadService.class);
+
+        when(credentialManager.loadStoredCredential()).thenReturn(null);
+
+        googleDriveService = new GoogleDriveService(
+                settings,
+                credentialManager,
+                gateway,
+                jdbcTemplate,
+                databaseReloadService);
+
+        activeCredential = mock(Credential.class);
+        setPrivateField(googleDriveService, "activeCredential", activeCredential);
+    }
+
+    @Test
+    void onShutdownShutsDownDatabaseBeforeUploading() {
+        googleDriveService.setShutdownSaveEnabled(true);
+
+        googleDriveService.onShutdown();
+
+        InOrder inOrder = inOrder(databaseReloadService, gateway);
+        inOrder.verify(databaseReloadService).shutdown();
+        inOrder.verify(gateway).uploadDatabaseToDrive(activeCredential);
+    }
+
+    @Test
+    void onShutdownSkipsUploadWhenDatabaseShutdownFails() {
+        googleDriveService.setShutdownSaveEnabled(true);
+        doThrow(new RuntimeException("boom")).when(databaseReloadService).shutdown();
+
+        googleDriveService.onShutdown();
+
+        verify(gateway, never()).uploadDatabaseToDrive(activeCredential);
+    }
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/com/studysync/integration/drive/GoogleDriveServiceTest.java
+++ b/src/test/java/com/studysync/integration/drive/GoogleDriveServiceTest.java
@@ -10,6 +10,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -73,6 +75,37 @@ class GoogleDriveServiceTest {
         googleDriveService.onShutdown();
 
         verify(gateway, never()).uploadDatabaseToDrive(activeCredential);
+    }
+
+    @Test
+    void uploadDatabaseSnapshotUsesShutdownReconnectCycle() {
+        Runnable preReloadListener = mock(Runnable.class);
+        Runnable reloadListener = mock(Runnable.class);
+        googleDriveService.addPreReloadListener(preReloadListener);
+        googleDriveService.addReloadListener(reloadListener);
+        when(gateway.uploadDatabaseToDrive(activeCredential)).thenReturn(true);
+
+        boolean uploaded = googleDriveService.uploadDatabaseSnapshot();
+
+        assertTrue(uploaded);
+        InOrder inOrder = inOrder(preReloadListener, databaseReloadService, gateway, reloadListener);
+        inOrder.verify(preReloadListener).run();
+        inOrder.verify(databaseReloadService).shutdown();
+        inOrder.verify(gateway).uploadDatabaseToDrive(activeCredential);
+        inOrder.verify(databaseReloadService).reconnect();
+        inOrder.verify(reloadListener).run();
+    }
+
+    @Test
+    void uploadDatabaseSnapshotReturnsFalseWhenReconnectFails() {
+        when(gateway.uploadDatabaseToDrive(activeCredential)).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(databaseReloadService).reconnect();
+
+        boolean uploaded = googleDriveService.uploadDatabaseSnapshot();
+
+        assertFalse(uploaded);
+        verify(databaseReloadService).shutdown();
+        verify(databaseReloadService).reconnect();
     }
 
     private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {


### PR DESCRIPTION
## **Fix study session persistence and add recovery safeguards**

### Description

A bug was reported where study sessions and other recent changes could appear saved in the UI but were not reliably durable in the local database file. In the reported flow, the app later uploaded or reloaded a stale database snapshot, which caused the missing data to reappear as lost after restart or cross-device sync.

#### This PR hardens the local persistence and Drive sync flow around study sessions, improves recovery/visibility of active and incomplete session state, and adds regression coverage for the affected paths.

### What changed
- hardened study-session persistence after start, completion, deletion, and related goal updates
- amended the shutdown/upload flow so Drive upload happens from a durable DB state
- hardened manual Drive upload/local-save behavior around the affected persistence path
- improved UI reload behavior so Drive downloads are reflected on the first attempt
- prevented planner refresh from overwriting in-progress session notes
- restored active sessions even when they span midnight, while keeping the session logged under its original start date
- added regression tests covering:
- session start/end persistence
- incomplete-session recovery
- active-session recovery across day boundaries
- shutdown/manual-upload durability ordering

### Why

The goal is to prevent cases where the UI implies a session was saved, but the local database file or uploaded Drive snapshot does not actually contain the latest committed session state.

### Testing
- added persistence-focused automated tests for study-session recovery and Drive durability paths
- verified:
   - ./gradlew compileJava
   - ./gradlew test --tests com.studysync.integration.drive.GoogleDriveServiceTest --tests com.studysync.domain.service.StudyServicePersistenceTest --tests com.studysync.config.DatabaseReloadServiceTest
