### PR TITLE
Move missed-goal retry into task planner

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,6 +109,12 @@ install_files() {
     mkdir -p "$BIN_DIR"
     mkdir -p "$APPLICATIONS_DIR"
     mkdir -p "$ICONS_DIR"
+
+    # Remove previous application jars before copying the newly built release.
+    # Dependency jars are kept; only StudySync's own versioned jars are replaced.
+    find "$INSTALL_DIR/lib" -maxdepth 1 -type f \
+        \( -name "StudySync-*.jar" -o -name "studysync-*.jar" \) \
+        -delete
     
     if [[ "$RELEASE_MODE" == true ]]; then
         # Copy from release tarball
@@ -130,7 +136,10 @@ install_files() {
         
         # Copy dependencies
         local install_lib_dir
-        install_lib_dir=$(find "$PROJECT_ROOT/build/install" -mindepth 2 -maxdepth 2 -type d -name lib | head -1)
+        install_lib_dir=""
+        if [[ -d "$PROJECT_ROOT/build/install" ]]; then
+            install_lib_dir=$(find "$PROJECT_ROOT/build/install" -mindepth 2 -maxdepth 2 -type d -name lib | head -1)
+        fi
         if [[ -n "$install_lib_dir" && -d "$install_lib_dir" ]]; then
             cp "$install_lib_dir/"*.jar "$INSTALL_DIR/lib/" 2>/dev/null || true
         fi
@@ -160,12 +169,22 @@ create_launcher() {
     # Prefer executable jar when available; otherwise use classpath mode with plain jar
     local main_jar
     local launch_mode
-    main_jar=$(find "$INSTALL_DIR/lib" \( -name "StudySync-*.jar" -o -name "studysync-*.jar" \) | grep -v "\-plain.jar" | head -1)
+    main_jar=$(find "$INSTALL_DIR/lib" -maxdepth 1 -type f \
+        \( -name "StudySync-*.jar" -o -name "studysync-*.jar" \) \
+        ! -name "*-plain.jar" -printf "%T@ %p\n" \
+        | sort -nr \
+        | head -1 \
+        | cut -d' ' -f2-)
 
     if [[ -n "$main_jar" ]]; then
         launch_mode="jar"
     else
-        main_jar=$(find "$INSTALL_DIR/lib" \( -name "StudySync-*-plain.jar" -o -name "studysync-*-plain.jar" \) | head -1)
+        main_jar=$(find "$INSTALL_DIR/lib" -maxdepth 1 -type f \
+            \( -name "StudySync-*-plain.jar" -o -name "studysync-*-plain.jar" \) \
+            -printf "%T@ %p\n" \
+            | sort -nr \
+            | head -1 \
+            | cut -d' ' -f2-)
         if [[ -z "$main_jar" ]]; then
             print_error "Application JAR not found in $INSTALL_DIR/lib"
             exit 1

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -46,6 +46,7 @@ public class StudyGoal {
             g.description,
             g.task_id,
             COALESCE(g.status, 'ACTIVE') AS status,
+            COALESCE(g.abandoned_explicitly, FALSE) AS abandoned_explicitly,
             g.achieved_attempt_id,
             g.created_at AS goal_created_at,
             g.updated_at AS goal_updated_at,
@@ -87,6 +88,7 @@ public class StudyGoal {
     private boolean failed;
 
     private GoalStatus status = GoalStatus.ACTIVE;
+    private boolean abandonedExplicitly;
     private String achievedAttemptId;
     private String attemptId;
     private String replannedFromAttemptId;
@@ -161,13 +163,13 @@ public class StudyGoal {
         this.taskId = taskId;
         this.replannedForDate = replannedForDate;
         this.failed = failed;
-        this.status = failed ? GoalStatus.ABANDONED : achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
+        this.status = achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
         this.attemptOutcome = failed ? AttemptOutcome.MISSED : achieved ? AttemptOutcome.ACHIEVED : AttemptOutcome.PENDING;
     }
 
     private StudyGoal(String id, LocalDate date, String description, String taskId,
-                      GoalStatus status, String achievedAttemptId, String attemptId,
-                      String replannedFromAttemptId, AttemptOutcome attemptOutcome,
+                      GoalStatus status, boolean abandonedExplicitly, String achievedAttemptId,
+                      String attemptId, String replannedFromAttemptId, AttemptOutcome attemptOutcome,
                       String reasonIfNotAchieved, LocalDateTime outcomeAt,
                       int attemptNumber, int missedAttemptCount) {
         this.id = id;
@@ -175,6 +177,7 @@ public class StudyGoal {
         this.description = description;
         this.taskId = taskId;
         this.status = status;
+        this.abandonedExplicitly = abandonedExplicitly;
         this.achievedAttemptId = achievedAttemptId;
         this.attemptId = attemptId;
         this.replannedFromAttemptId = replannedFromAttemptId;
@@ -238,12 +241,12 @@ public class StudyGoal {
         this.failed = failed;
         if (failed) {
             this.achieved = false;
-            this.status = GoalStatus.ABANDONED;
             this.attemptOutcome = AttemptOutcome.MISSED;
         }
     }
 
     public GoalStatus getStatus() { return status; }
+    public boolean isAbandonedExplicitly() { return abandonedExplicitly; }
     public String getAchievedAttemptId() { return achievedAttemptId; }
     public String getAttemptId() { return attemptId; }
     public String getReplannedFromAttemptId() { return replannedFromAttemptId; }
@@ -275,7 +278,7 @@ public class StudyGoal {
             date = LocalDate.now();
         }
         if (status == null) {
-            status = failed ? GoalStatus.ABANDONED : achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
+            status = abandonedExplicitly ? GoalStatus.ABANDONED : achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
         }
         if (attemptOutcome == null) {
             attemptOutcome = failed ? AttemptOutcome.MISSED : achieved ? AttemptOutcome.ACHIEVED : AttemptOutcome.PENDING;
@@ -308,14 +311,16 @@ public class StudyGoal {
             MERGE INTO study_goals (
                 id, date, description, achieved, reason_if_not_achieved,
                 days_delayed, is_delayed, points_deducted, task_id,
-                replanned_for_date, failed, status, achieved_attempt_id, updated_at
+                replanned_for_date, failed, status, abandoned_explicitly,
+                achieved_attempt_id, updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             """;
         jdbcTemplate.update(sql,
                 id, date, description, status == GoalStatus.ACHIEVED, reasonIfNotAchieved,
                 daysDelayed, isDelayed, pointsDeducted, taskId,
-                replannedForDate, status == GoalStatus.ABANDONED, status.name(), achievedAttemptId);
+                replannedForDate, attemptOutcome == AttemptOutcome.MISSED, status.name(),
+                abandonedExplicitly, achievedAttemptId);
     }
 
     private void upsertAttempt() {
@@ -671,7 +676,7 @@ public class StudyGoal {
         int rows = jdbcTemplate.update("""
             UPDATE study_goals
             SET status = 'ABANDONED', achieved_attempt_id = NULL, achieved = FALSE, failed = TRUE,
-                updated_at = CURRENT_TIMESTAMP
+                abandoned_explicitly = TRUE, updated_at = CURRENT_TIMESTAMP
             WHERE id = ?
             """, goalId);
         return rows > 0;
@@ -684,6 +689,7 @@ public class StudyGoal {
                 rs.getString("description"),
                 rs.getString("task_id"),
                 parseGoalStatus(rs.getString("status")),
+                rs.getBoolean("abandoned_explicitly"),
                 rs.getString("achieved_attempt_id"),
                 rs.getString("attempt_id"),
                 rs.getString("replanned_from_attempt_id"),

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -487,6 +487,26 @@ public class StudyGoal {
         return jdbcTemplate.query(sql, getAttemptViewMapper(), taskId);
     }
 
+    public static boolean updateDetails(String goalId, String description, LocalDate pendingPlannedForDate) {
+        if (jdbcTemplate == null || goalId == null || goalId.isBlank()
+                || description == null || description.isBlank()) {
+            return false;
+        }
+        int parentRows = jdbcTemplate.update("""
+            UPDATE study_goals
+            SET description = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """, description.trim(), goalId);
+        if (pendingPlannedForDate != null) {
+            jdbcTemplate.update("""
+                UPDATE study_goal_attempts
+                SET planned_for_date = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE goal_id = ? AND outcome = 'PENDING'
+                """, pendingPlannedForDate, goalId);
+        }
+        return parentRows > 0;
+    }
+
     public static Set<String> findAchievedTaskDatePairs(LocalDate rangeStart, LocalDate rangeEnd) {
         if (jdbcTemplate == null || rangeStart == null || rangeEnd == null) {
             return Set.of();

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -527,6 +527,40 @@ public class StudyGoal {
         return result;
     }
 
+    public static Set<String> findHandledTaskDatePairs(LocalDate rangeStart, LocalDate rangeEnd) {
+        if (jdbcTemplate == null || rangeStart == null || rangeEnd == null) {
+            return Set.of();
+        }
+        String sql = """
+            WITH RECURSIVE handled_attempts (
+                task_id, attempt_id, planned_for_date, outcome, replanned_from_attempt_id, depth
+            ) AS (
+                SELECT g.task_id, a.id, a.planned_for_date, a.outcome, a.replanned_from_attempt_id, 0
+                FROM study_goals g
+                JOIN study_goal_attempts a ON a.goal_id = g.id
+                WHERE g.task_id IS NOT NULL
+                  AND a.outcome = 'ACHIEVED'
+                UNION ALL
+                SELECT h.task_id, parent.id, parent.planned_for_date, parent.outcome,
+                       parent.replanned_from_attempt_id, h.depth + 1
+                FROM study_goal_attempts parent
+                JOIN handled_attempts h ON h.replanned_from_attempt_id = parent.id
+                WHERE h.depth < 20
+            )
+            SELECT DISTINCT task_id, planned_for_date
+            FROM handled_attempts
+            WHERE planned_for_date >= ?
+              AND planned_for_date <= ?
+              AND outcome IN ('ACHIEVED', 'MISSED')
+            """;
+        Set<String> result = new HashSet<>();
+        jdbcTemplate.query(sql, (rs, rowNum) -> {
+            result.add(rs.getString("task_id") + "|" + rs.getDate("planned_for_date").toLocalDate());
+            return null;
+        }, rangeStart, rangeEnd);
+        return result;
+    }
+
     public static boolean hasAchievedGoalForTask(String taskId, LocalDate date) {
         if (jdbcTemplate == null || taskId == null || taskId.isBlank() || date == null) {
             return false;
@@ -540,6 +574,35 @@ public class StudyGoal {
               AND a.outcome = 'ACHIEVED'
             """;
         Integer count = jdbcTemplate.queryForObject(sql, Integer.class, taskId, date);
+        return count != null && count > 0;
+    }
+
+    public static boolean hasHandledGoalForTaskOccurrence(String taskId, LocalDate occurrenceDate) {
+        if (jdbcTemplate == null || taskId == null || taskId.isBlank() || occurrenceDate == null) {
+            return false;
+        }
+        String sql = """
+            WITH RECURSIVE handled_attempts (
+                attempt_id, planned_for_date, outcome, replanned_from_attempt_id, depth
+            ) AS (
+                SELECT a.id, a.planned_for_date, a.outcome, a.replanned_from_attempt_id, 0
+                FROM study_goals g
+                JOIN study_goal_attempts a ON a.goal_id = g.id
+                WHERE g.task_id = ?
+                  AND a.outcome = 'ACHIEVED'
+                UNION ALL
+                SELECT parent.id, parent.planned_for_date, parent.outcome,
+                       parent.replanned_from_attempt_id, h.depth + 1
+                FROM study_goal_attempts parent
+                JOIN handled_attempts h ON h.replanned_from_attempt_id = parent.id
+                WHERE h.depth < 20
+            )
+            SELECT COUNT(*)
+            FROM handled_attempts
+            WHERE planned_for_date = ?
+              AND outcome IN ('ACHIEVED', 'MISSED')
+            """;
+        Integer count = jdbcTemplate.queryForObject(sql, Integer.class, taskId, occurrenceDate);
         return count != null && count > 0;
     }
 

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -286,6 +286,7 @@ public class StudyGoal {
         if (attemptId == null || attemptId.isBlank()) {
             attemptId = UUID.randomUUID().toString();
         }
+        // Parent lifecycle mirrors the current attempt outcome on write.
         if (attemptOutcome == AttemptOutcome.ACHIEVED) {
             status = GoalStatus.ACHIEVED;
             achievedAttemptId = attemptId;
@@ -660,6 +661,14 @@ public class StudyGoal {
         if (jdbcTemplate == null || goalId == null || goalId.isBlank() || plannedForDate == null) {
             return false;
         }
+        Integer activeGoalCount = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*) FROM study_goals
+            WHERE id = ? AND status = 'ACTIVE'
+            """, Integer.class, goalId);
+        if (activeGoalCount == null || activeGoalCount == 0) {
+            return false;
+        }
+
         Integer pendingCount = jdbcTemplate.queryForObject("""
             SELECT COUNT(*) FROM study_goal_attempts
             WHERE goal_id = ? AND outcome = 'PENDING'

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -1,205 +1,156 @@
-
 package com.studysync.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 /**
- * Domain entity representing a study goal in the StudySync personal development system.
- * 
- * <p>StudyGoal enables users to set daily learning objectives and track their achievement over time.
- * This supports habit formation, progress tracking, and reflection on learning outcomes. Goals can
- * be simple daily objectives or more complex learning targets.</p>
- * 
- * <p><strong>Goal Lifecycle:</strong>
- * <ol>
- *   <li><strong>Creation:</strong> Goal is set with a description and current date</li>
- *   <li><strong>Tracking:</strong> User works toward achieving the goal throughout the day</li>
- *   <li><strong>Evaluation:</strong> At day's end, goal is marked achieved or not achieved</li>
- *   <li><strong>Reflection:</strong> If not achieved, user can record reasons for learning</li>
- * </ol></p>
- * 
- * <p><strong>Usage Examples:</strong>
- * <pre>
- * // Create a simple daily goal
- * StudyGoal goal = new StudyGoal("Complete 2 hours of focused study");
- * 
- * // Mark goal as achieved
- * goal.setAchieved(true);
- * 
- * // Record reason if not achieved
- * goal.setAchieved(false);
- * goal.setReasonIfNotAchieved("Had unexpected meeting that ran long");
- * </pre></p>
- * 
- * <p><strong>Business Rules:</strong>
- * <ul>
- *   <li>Each goal is automatically assigned a unique ID and current date</li>
- *   <li>Goals default to not achieved until explicitly marked</li>
- *   <li>Reasons for non-achievement are optional but encouraged for reflection</li>
- *   <li>Goals cannot be modified once created (description is immutable)</li>
- * </ul></p>
- * 
- * <p><strong>Integration:</strong> StudyGoals integrate with the daily reflection system
- * and analytics to provide insights into learning patterns and goal achievement rates.</p>
- * 
- * @author StudySync Development Team
- * @version 0.1.2
- * @since 0.1.0
- * @see DailyReflection
+ * Domain entity representing a study goal.
+ *
+ * <p>The database model separates a goal's intent from its scheduled attempts:
+ * {@code study_goals} is the parent intent, while {@code study_goal_attempts}
+ * stores every planned try and outcome. This class intentionally keeps the old
+ * view-style API used by the UI: each queried {@code StudyGoal} instance is a
+ * parent goal plus one selected attempt context.</p>
  */
 public class StudyGoal {
     private static final Logger logger = LoggerFactory.getLogger(StudyGoal.class);
     private static JdbcTemplate jdbcTemplate;
-    
+
+    public enum GoalStatus {
+        ACTIVE,
+        ACHIEVED,
+        ABANDONED
+    }
+
+    public enum AttemptOutcome {
+        PENDING,
+        ACHIEVED,
+        MISSED
+    }
+
+    private static final String SELECT_ATTEMPT_VIEW = """
+        SELECT
+            g.id,
+            g.description,
+            g.task_id,
+            COALESCE(g.status, 'ACTIVE') AS status,
+            g.achieved_attempt_id,
+            g.created_at AS goal_created_at,
+            g.updated_at AS goal_updated_at,
+            a.id AS attempt_id,
+            a.planned_for_date,
+            a.replanned_from_attempt_id,
+            COALESCE(a.outcome, 'PENDING') AS attempt_outcome,
+            a.reason_if_not_achieved,
+            a.outcome_at,
+            a.created_at AS attempt_created_at,
+            a.updated_at AS attempt_updated_at,
+            (
+                SELECT COUNT(*)
+                FROM study_goal_attempts x
+                WHERE x.goal_id = g.id
+                  AND (x.created_at < a.created_at OR (x.created_at = a.created_at AND x.id <= a.id))
+            ) AS attempt_number,
+            (
+                SELECT COUNT(*)
+                FROM study_goal_attempts m
+                WHERE m.goal_id = g.id
+                  AND m.outcome = 'MISSED'
+                  AND (m.created_at < a.created_at OR (m.created_at = a.created_at AND m.id <= a.id))
+            ) AS missed_attempt_count
+        FROM study_goals g
+        JOIN study_goal_attempts a ON a.goal_id = g.id
+        """;
+
+    private String id;
+    private LocalDate date;
+    private String description;
+    private boolean achieved;
+    private String reasonIfNotAchieved;
+    private int daysDelayed;
+    private boolean isDelayed;
+    private int pointsDeducted;
+    private String taskId;
+    private LocalDate replannedForDate;
+    private boolean failed;
+
+    private GoalStatus status = GoalStatus.ACTIVE;
+    private String achievedAttemptId;
+    private String attemptId;
+    private String replannedFromAttemptId;
+    private AttemptOutcome attemptOutcome = AttemptOutcome.PENDING;
+    private LocalDateTime outcomeAt;
+    private int attemptNumber = 1;
+    private int missedAttemptCount = 0;
+
     public static void setJdbcTemplate(JdbcTemplate template) {
         jdbcTemplate = template;
     }
-    
-    /** Unique identifier for this study goal. */
-    private String id;
-    
-    /** The date this goal was created for (target achievement date). */
-    private LocalDate date;
-    
-    /** Description of what the user wants to achieve. */
-    private String description;
-    
-    /** Whether this goal has been achieved. */
-    private boolean achieved;
-    
-    /** Optional explanation of why the goal was not achieved (for reflection). */
-    private String reasonIfNotAchieved;
-    
-    /** Number of days this goal has been delayed (0 for goals on original date). */
-    private int daysDelayed;
-    
-    /** Whether this goal is a transferred goal from a previous day. */
-    private boolean isDelayed;
-    
-    /** Points deducted due to delays (accumulates over time). */
-    private int pointsDeducted;
-    
-    /** Optional ID of the task this goal is linked to. */
-    private String taskId;
 
-    /**
-     * When non-null, this goal has been manually rescheduled to appear on this specific date.
-     * It is excluded from automatic delay carry-forward and only surfaces on this date.
-     */
-    private LocalDate replannedForDate;
-
-    /** Whether this goal has been marked as failed (overdue beyond threshold or user-dismissed). */
-    private boolean failed;
-
-    /**
-     * Default constructor creating a study goal with auto-generated ID and current date.
-     * 
-     * <p>The goal is initialized as not achieved. The description must be set separately.</p>
-     */
     public StudyGoal() {
-        this.id = java.util.UUID.randomUUID().toString();
+        this.id = UUID.randomUUID().toString();
         this.date = LocalDate.now();
-        this.achieved = false;
-        this.daysDelayed = 0;
-        this.isDelayed = false;
-        this.pointsDeducted = 0;
-        this.failed = false;
+        this.status = GoalStatus.ACTIVE;
+        this.attemptOutcome = AttemptOutcome.PENDING;
     }
 
-    /**
-     * Creates a study goal with the specified description.
-     * 
-     * <p>The goal is automatically assigned a unique ID, set to the current date,
-     * and initialized as not achieved.</p>
-     * 
-     * @param description what the user wants to achieve
-     */
     public StudyGoal(String description) {
         this();
         this.description = description;
     }
-    
-    /**
-     * Creates a study goal with the specified description and optional task link.
-     * 
-     * @param description what the user wants to achieve
-     * @param taskId optional ID of the task this goal is linked to
-     */
+
     public StudyGoal(String description, String taskId) {
         this(description);
         this.taskId = taskId;
     }
 
-    /**
-     * Full constructor for creating StudyGoal from JSON or with all parameters.
-     * 
-     * <p>This constructor provides null-safety by generating defaults for ID and date
-     * if not provided. Used primarily for JSON deserialization and testing.</p>
-     * 
-     * @param id unique identifier (auto-generated if null)
-     * @param date goal date (current date if null)
-     * @param description goal description
-     * @param achieved whether the goal has been achieved
-     * @param reasonIfNotAchieved explanation if not achieved
-     */
     @JsonCreator
     public StudyGoal(@JsonProperty("id") String id,
-                    @JsonProperty("date") LocalDate date,
-                    @JsonProperty("description") String description,
-                    @JsonProperty("achieved") boolean achieved,
-                    @JsonProperty("reasonIfNotAchieved") String reasonIfNotAchieved) {
-        this.id = id != null ? id : java.util.UUID.randomUUID().toString();
+                     @JsonProperty("date") LocalDate date,
+                     @JsonProperty("description") String description,
+                     @JsonProperty("achieved") boolean achieved,
+                     @JsonProperty("reasonIfNotAchieved") String reasonIfNotAchieved) {
+        this.id = id != null ? id : UUID.randomUUID().toString();
         this.date = date != null ? date : LocalDate.now();
         this.description = description;
         this.achieved = achieved;
         this.reasonIfNotAchieved = reasonIfNotAchieved;
-        this.daysDelayed = 0;
-        this.isDelayed = false;
-        this.pointsDeducted = 0;
-    }
-    
-    /**
-     * Full constructor for creating StudyGoal with all delay tracking fields.
-     * Used internally for database operations.
-     */
-    public StudyGoal(String id, LocalDate date, String description, boolean achieved,
-                    String reasonIfNotAchieved, int daysDelayed,
-                    boolean isDelayed, int pointsDeducted, String taskId) {
-        this(id, date, description, achieved, reasonIfNotAchieved,
-             daysDelayed, isDelayed, pointsDeducted, taskId, null);
+        this.status = achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
+        this.attemptOutcome = achieved ? AttemptOutcome.ACHIEVED : AttemptOutcome.PENDING;
     }
 
-    /**
-     * Full constructor including the optional replanned-for date.
-     * Used when rescheduling goals (failed defaults to false).
-     */
     public StudyGoal(String id, LocalDate date, String description, boolean achieved,
-                    String reasonIfNotAchieved, int daysDelayed,
-                    boolean isDelayed, int pointsDeducted, String taskId,
-                    LocalDate replannedForDate) {
+                     String reasonIfNotAchieved, int daysDelayed,
+                     boolean isDelayed, int pointsDeducted, String taskId) {
         this(id, date, description, achieved, reasonIfNotAchieved,
-             daysDelayed, isDelayed, pointsDeducted, taskId, replannedForDate, false);
+                daysDelayed, isDelayed, pointsDeducted, taskId, null, false);
     }
 
-    /**
-     * Full constructor including failed flag.
-     * Used by the row mapper.
-     */
     public StudyGoal(String id, LocalDate date, String description, boolean achieved,
-                    String reasonIfNotAchieved, int daysDelayed,
-                    boolean isDelayed, int pointsDeducted, String taskId,
-                    LocalDate replannedForDate, boolean failed) {
-        this.id = id != null ? id : java.util.UUID.randomUUID().toString();
+                     String reasonIfNotAchieved, int daysDelayed,
+                     boolean isDelayed, int pointsDeducted, String taskId,
+                     LocalDate replannedForDate) {
+        this(id, date, description, achieved, reasonIfNotAchieved,
+                daysDelayed, isDelayed, pointsDeducted, taskId, replannedForDate, false);
+    }
+
+    public StudyGoal(String id, LocalDate date, String description, boolean achieved,
+                     String reasonIfNotAchieved, int daysDelayed,
+                     boolean isDelayed, int pointsDeducted, String taskId,
+                     LocalDate replannedForDate, boolean failed) {
+        this.id = id != null ? id : UUID.randomUUID().toString();
         this.date = date != null ? date : LocalDate.now();
         this.description = description;
         this.achieved = achieved;
@@ -210,660 +161,559 @@ public class StudyGoal {
         this.taskId = taskId;
         this.replannedForDate = replannedForDate;
         this.failed = failed;
+        this.status = failed ? GoalStatus.ABANDONED : achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
+        this.attemptOutcome = failed ? AttemptOutcome.MISSED : achieved ? AttemptOutcome.ACHIEVED : AttemptOutcome.PENDING;
     }
 
-    /**
-     * Gets the unique identifier of this study goal.
-     * 
-     * @return the goal ID
-     */
+    private StudyGoal(String id, LocalDate date, String description, String taskId,
+                      GoalStatus status, String achievedAttemptId, String attemptId,
+                      String replannedFromAttemptId, AttemptOutcome attemptOutcome,
+                      String reasonIfNotAchieved, LocalDateTime outcomeAt,
+                      int attemptNumber, int missedAttemptCount) {
+        this.id = id;
+        this.date = date;
+        this.description = description;
+        this.taskId = taskId;
+        this.status = status;
+        this.achievedAttemptId = achievedAttemptId;
+        this.attemptId = attemptId;
+        this.replannedFromAttemptId = replannedFromAttemptId;
+        this.attemptOutcome = attemptOutcome;
+        this.reasonIfNotAchieved = reasonIfNotAchieved;
+        this.outcomeAt = outcomeAt;
+        this.attemptNumber = Math.max(1, attemptNumber);
+        this.missedAttemptCount = Math.max(0, missedAttemptCount);
+        this.achieved = attemptOutcome == AttemptOutcome.ACHIEVED;
+        this.failed = attemptOutcome == AttemptOutcome.MISSED || status == GoalStatus.ABANDONED;
+        this.isDelayed = this.missedAttemptCount > 0 || this.failed;
+        this.daysDelayed = this.missedAttemptCount;
+        this.pointsDeducted = this.missedAttemptCount;
+        this.replannedForDate = replannedFromAttemptId != null && attemptOutcome == AttemptOutcome.PENDING ? date : null;
+    }
+
     public String getId() { return id; }
-    
-    /**
-     * Sets the unique identifier for this study goal.
-     * 
-     * @param id the goal ID
-     */
     public void setId(String id) { this.id = id; }
 
-    /**
-     * Gets the date this goal was created for.
-     * 
-     * @return the goal date
-     */
     public LocalDate getDate() { return date; }
-    
-    /**
-     * Sets the date for this goal.
-     * 
-     * @param date the goal date
-     */
     public void setDate(LocalDate date) { this.date = date; }
 
-    /**
-     * Gets the description of what should be achieved.
-     * 
-     * @return the goal description
-     */
     public String getDescription() { return description; }
-    
-    /**
-     * Sets the description of what should be achieved.
-     * 
-     * @param description the goal description
-     */
     public void setDescription(String description) { this.description = description; }
 
-    /**
-     * Determines if this goal has been achieved.
-     * 
-     * @return true if the goal has been achieved, false otherwise
-     */
     public boolean isAchieved() { return achieved; }
-    
-    /**
-     * Sets whether this goal has been achieved.
-     * 
-     * @param achieved true if the goal has been achieved
-     */
-    public void setAchieved(boolean achieved) { this.achieved = achieved; }
-
-    /**
-     * Gets the reason why this goal was not achieved.
-     * 
-     * <p>This is used for reflection and learning from unachieved goals.
-     * Only meaningful when {@code achieved} is false.</p>
-     * 
-     * @return the reason for non-achievement, or null if not provided
-     */
-    public String getReasonIfNotAchieved() { return reasonIfNotAchieved; }
-    
-    /**
-     * Sets the reason why this goal was not achieved.
-     * 
-     * <p>This supports reflection and helps identify patterns in goal achievement.
-     * Should be used when marking a goal as not achieved.</p>
-     * 
-     * @param reasonIfNotAchieved explanation of why the goal wasn't achieved
-     */
-    public void setReasonIfNotAchieved(String reasonIfNotAchieved) { 
-        this.reasonIfNotAchieved = reasonIfNotAchieved; 
+    public void setAchieved(boolean achieved) {
+        this.achieved = achieved;
+        if (achieved) {
+            this.failed = false;
+            this.status = GoalStatus.ACHIEVED;
+            this.attemptOutcome = AttemptOutcome.ACHIEVED;
+        } else if (this.attemptOutcome == AttemptOutcome.ACHIEVED) {
+            this.status = GoalStatus.ACTIVE;
+            this.attemptOutcome = AttemptOutcome.PENDING;
+        }
     }
 
+    public String getReasonIfNotAchieved() { return reasonIfNotAchieved; }
+    public void setReasonIfNotAchieved(String reasonIfNotAchieved) {
+        this.reasonIfNotAchieved = reasonIfNotAchieved;
+    }
 
-    /**
-     * Gets the number of days this goal has been delayed.
-     * 
-     * @return days delayed (0 for goals on original date)
-     */
     public int getDaysDelayed() { return daysDelayed; }
-    
-    /**
-     * Sets the number of days this goal has been delayed.
-     * 
-     * @param daysDelayed days delayed
-     */
     public void setDaysDelayed(int daysDelayed) { this.daysDelayed = daysDelayed; }
 
-    /**
-     * Checks if this goal is delayed (transferred from a previous day).
-     * 
-     * @return true if the goal is delayed
-     */
     public boolean isDelayed() { return isDelayed; }
-    
-    /**
-     * Sets whether this goal is delayed.
-     * 
-     * @param delayed true if the goal is delayed
-     */
     public void setDelayed(boolean delayed) { this.isDelayed = delayed; }
 
-    /**
-     * Gets the total points deducted due to delays.
-     * 
-     * @return points deducted
-     */
     public int getPointsDeducted() { return pointsDeducted; }
-    
-    /**
-     * Sets the points deducted due to delays.
-     * 
-     * @param pointsDeducted points deducted
-     */
     public void setPointsDeducted(int pointsDeducted) { this.pointsDeducted = pointsDeducted; }
-    
-    /**
-     * Gets the ID of the task this goal is linked to.
-     * 
-     * @return task ID, or null if not linked to any task
-     */
+
     public String getTaskId() { return taskId; }
-    
-    /**
-     * Sets the ID of the task this goal is linked to.
-     *
-     * @param taskId task ID, or null to unlink from task
-     */
     public void setTaskId(String taskId) { this.taskId = taskId; }
 
-    /**
-     * Gets the date this goal was manually rescheduled to appear on.
-     * When non-null the goal surfaces only on this date and is excluded
-     * from automatic delay carry-forward.
-     *
-     * @return the replanned date, or null if not rescheduled
-     */
     public LocalDate getReplannedForDate() { return replannedForDate; }
+    public void setReplannedForDate(LocalDate replannedForDate) { this.replannedForDate = replannedForDate; }
 
-    /**
-     * Sets the date this goal should be manually rescheduled to.
-     *
-     * @param replannedForDate the target date, or null to clear
-     */
-    public void setReplannedForDate(LocalDate replannedForDate) {
-        this.replannedForDate = replannedForDate;
-    }
-
-    /**
-     * Checks if this goal has been marked as failed.
-     *
-     * @return true if the goal is failed
-     */
     public boolean isFailed() { return failed; }
-
-    /**
-     * Sets whether this goal is failed.
-     *
-     * @param failed true to mark as failed
-     */
-    public void setFailed(boolean failed) { this.failed = failed; }
-
-    /**
-     * Calculate the delay penalty based on days delayed.
-     * Formula: 5 points for first delay, then 2 points per additional day.
-     * 
-     * @return penalty points for the current delay
-     */
-    public int calculateDelayPenalty() {
-        if (daysDelayed == 0) return 0;
-        if (daysDelayed == 1) return 5; // First delay
-        return 5 + (daysDelayed - 1) * 2; // Additional days
+    public void setFailed(boolean failed) {
+        this.failed = failed;
+        if (failed) {
+            this.achieved = false;
+            this.status = GoalStatus.ABANDONED;
+            this.attemptOutcome = AttemptOutcome.MISSED;
+        }
     }
-    
-    /**
-     * Get the color intensity for UI display based on delay.
-     * Returns a value between 0.0 (no delay/green) and 1.0 (max delay/red).
-     * 
-     * @return color intensity for delayed goal visualization
-     */
+
+    public GoalStatus getStatus() { return status; }
+    public String getAchievedAttemptId() { return achievedAttemptId; }
+    public String getAttemptId() { return attemptId; }
+    public String getReplannedFromAttemptId() { return replannedFromAttemptId; }
+    public AttemptOutcome getAttemptOutcome() { return attemptOutcome; }
+    public LocalDateTime getOutcomeAt() { return outcomeAt; }
+    public int getAttemptNumber() { return attemptNumber; }
+    public int getMissedAttemptCount() { return missedAttemptCount; }
+
+    public int calculateDelayPenalty() {
+        return missedAttemptCount;
+    }
+
     public double getDelayColorIntensity() {
         if (!isDelayed) return 0.0;
-        // Orange starts at day 1, gradually moves to red
-        return Math.min(1.0, daysDelayed / 7.0); // Max intensity at 7 days
+        return Math.min(1.0, missedAttemptCount / 5.0);
     }
 
-    /**
-     * Returns a string representation of this study goal.
-     * 
-     * <p>The format shows the goal description followed by a checkmark ([✓]) if achieved
-     * or an X ([x]) if not achieved. This provides a quick visual status indicator.</p>
-     * 
-     * @return a string representation showing goal description and achievement status
-     */
     @Override
     public String toString() {
-        return description + " - " + (achieved ? "[✓]" : "[x]");
+        return description + " - " + attemptOutcome;
     }
-    
-    // ==============================================================
-    // DATABASE OPERATIONS (Active Record Pattern)
-    // ==============================================================
-    
-    /**
-     * Save this study goal to the database (insert or update).
-     */
-    public StudyGoal save() {
-        if (jdbcTemplate == null) {
-            throw new IllegalStateException("JdbcTemplate not initialized. Make sure Spring context is loaded.");
-        }
-        
-        String sql = """
-            MERGE INTO study_goals (id, date, description, achieved, reason_if_not_achieved,
-                                   days_delayed, is_delayed, points_deducted, task_id,
-                                   replanned_for_date, failed, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-            """;
 
-        jdbcTemplate.update(sql,
-            this.id, this.date, this.description, this.achieved, this.reasonIfNotAchieved,
-            this.daysDelayed, this.isDelayed, this.pointsDeducted, this.taskId,
-            this.replannedForDate, this.failed
-        );
-        
-        logger.debug("StudyGoal saved: {} - {}", this.id, this.description);
+    public StudyGoal save() {
+        requireJdbcTemplate();
+        if (id == null || id.isBlank()) {
+            id = UUID.randomUUID().toString();
+        }
+        if (date == null) {
+            date = LocalDate.now();
+        }
+        if (status == null) {
+            status = failed ? GoalStatus.ABANDONED : achieved ? GoalStatus.ACHIEVED : GoalStatus.ACTIVE;
+        }
+        if (attemptOutcome == null) {
+            attemptOutcome = failed ? AttemptOutcome.MISSED : achieved ? AttemptOutcome.ACHIEVED : AttemptOutcome.PENDING;
+        }
+        if (attemptId == null || attemptId.isBlank()) {
+            attemptId = UUID.randomUUID().toString();
+        }
+        if (attemptOutcome == AttemptOutcome.ACHIEVED) {
+            status = GoalStatus.ACHIEVED;
+            achievedAttemptId = attemptId;
+            achieved = true;
+            failed = false;
+        } else if (status == GoalStatus.ACHIEVED) {
+            status = GoalStatus.ACTIVE;
+            achievedAttemptId = null;
+        }
+
+        upsertParent();
+        upsertAttempt();
+        logger.debug("StudyGoal saved: {} - {}", id, description);
         return this;
     }
-    
-    /**
-     * Delete this study goal from the database.
-     */
+
     public boolean delete() {
-        if (jdbcTemplate == null || this.id == null) {
-            return false;
-        }
-        
-        String sql = "DELETE FROM study_goals WHERE id = ?";
-        int rowsAffected = jdbcTemplate.update(sql, this.id);
-        boolean deleted = rowsAffected > 0;
-        
-        if (deleted) {
-            logger.info("StudyGoal deleted: {} - {}", this.id, this.description);
-        } else {
-            logger.warn("StudyGoal not found for deletion: {}", this.id);
-        }
-        
-        return deleted;
+        return deleteById(id);
     }
-    
-    // ==============================================================
-    // STATIC QUERY METHODS
-    // ==============================================================
-    
-    /**
-     * Get all study goals ordered by date (most recent first).
-     */
+
+    private void upsertParent() {
+        String sql = """
+            MERGE INTO study_goals (
+                id, date, description, achieved, reason_if_not_achieved,
+                days_delayed, is_delayed, points_deducted, task_id,
+                replanned_for_date, failed, status, achieved_attempt_id, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """;
+        jdbcTemplate.update(sql,
+                id, date, description, status == GoalStatus.ACHIEVED, reasonIfNotAchieved,
+                daysDelayed, isDelayed, pointsDeducted, taskId,
+                replannedForDate, status == GoalStatus.ABANDONED, status.name(), achievedAttemptId);
+    }
+
+    private void upsertAttempt() {
+        String sql = """
+            MERGE INTO study_goal_attempts (
+                id, goal_id, planned_for_date, replanned_from_attempt_id, outcome,
+                reason_if_not_achieved, outcome_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """;
+        LocalDateTime resolvedOutcomeAt = attemptOutcome == AttemptOutcome.PENDING ? null
+                : outcomeAt != null ? outcomeAt : LocalDateTime.now();
+        jdbcTemplate.update(sql,
+                attemptId, id, date, replannedFromAttemptId, attemptOutcome.name(),
+                reasonIfNotAchieved, resolvedOutcomeAt);
+    }
+
     public static List<StudyGoal> findAll() {
-        if (jdbcTemplate == null) {
-            throw new IllegalStateException("JdbcTemplate not initialized");
-        }
-        
-        String sql = "SELECT * FROM study_goals ORDER BY date DESC, created_at DESC";
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper());
-        logger.debug("Retrieved {} study goals", goals.size());
-        return goals;
+        requireJdbcTemplate();
+        String sql = SELECT_ATTEMPT_VIEW + """
+            ORDER BY a.planned_for_date DESC, a.created_at DESC
+            """;
+        return jdbcTemplate.query(sql, getAttemptViewMapper());
     }
-    
-    /**
-     * Find a study goal by its ID.
-     */
+
     public static Optional<StudyGoal> findById(String goalId) {
         if (jdbcTemplate == null || goalId == null) {
             return Optional.empty();
         }
-        
-        String sql = "SELECT * FROM study_goals WHERE id = ?";
-        try {
-            StudyGoal goal = jdbcTemplate.queryForObject(sql, getRowMapper(), goalId);
-            logger.debug("StudyGoal found: {}", goalId);
-            return Optional.ofNullable(goal);
-        } catch (Exception e) {
-            logger.debug("StudyGoal not found: {}", goalId);
-            return Optional.empty();
-        }
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE g.id = ?
+            ORDER BY
+                CASE a.outcome WHEN 'PENDING' THEN 0 WHEN 'ACHIEVED' THEN 1 ELSE 2 END,
+                a.planned_for_date DESC,
+                a.created_at DESC
+            LIMIT 1
+            """;
+        List<StudyGoal> goals = jdbcTemplate.query(sql, getAttemptViewMapper(), goalId);
+        return goals.stream().findFirst();
     }
-    
-    /**
-     * Get study goals for a specific date.
-     * Failed goals are excluded — use {@link #findAllByDate(LocalDate)} for views
-     * that need the complete history (e.g. calendar).
-     */
+
     public static List<StudyGoal> findByDate(LocalDate date) {
         if (jdbcTemplate == null || date == null) {
             return List.of();
         }
-
-        // Include goals originally planned for this date AND goals manually
-        // rescheduled (replanned) to appear on this date, regardless of achieved status.
-        // Failed goals are excluded from active views.
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE (failed = FALSE OR failed IS NULL)
-              AND (date = ? OR replanned_for_date = ?)
-            ORDER BY created_at
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE g.status <> 'ABANDONED'
+              AND a.planned_for_date = ?
+              AND a.outcome IN ('PENDING', 'ACHIEVED')
+            ORDER BY a.outcome ASC, g.created_at ASC
             """;
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date);
-        logger.debug("Retrieved {} study goals for date: {}", goals.size(), date);
-        return goals;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), date);
     }
 
-    /**
-     * Get all study goals for a specific date, including failed ones.
-     * Used by calendar view which shows the full history for each day.
-     */
     public static List<StudyGoal> findAllByDate(LocalDate date) {
         if (jdbcTemplate == null || date == null) {
             return List.of();
         }
-
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE (date = ? OR replanned_for_date = ?)
-            ORDER BY failed ASC, achieved DESC, created_at ASC
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE a.planned_for_date = ?
+            ORDER BY
+                CASE a.outcome WHEN 'PENDING' THEN 0 WHEN 'ACHIEVED' THEN 1 ELSE 2 END,
+                g.created_at ASC
             """;
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date);
-        logger.debug("Retrieved {} study goals (all statuses) for date: {}", goals.size(), date);
-        return goals;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), date);
     }
-    
-    /**
-     * Get study goals for a specific date including delayed goals that should appear on this date.
-     * This method returns:
-     * <ul>
-     *   <li>Goals originally created for the specified date</li>
-     *   <li>Unachieved goals from previous dates that are now delayed</li>
-     * </ul>
-     *
-     * @param date the date to retrieve goals for
-     * @return list of study goals including delayed ones, ordered by delay status and creation time
-     */
+
     public static List<StudyGoal> findByDateIncludingDelayed(LocalDate date) {
-        if (jdbcTemplate == null || date == null) {
-            return List.of();
-        }
-
-        // Delayed goals that were manually replanned are excluded from the automatic
-        // carry-forward path — they only surface via their replanned_for_date.
-        // Failed goals are excluded from active planner views.
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE (failed = FALSE OR failed IS NULL)
-              AND (date = ?
-               OR (is_delayed = TRUE AND achieved = FALSE AND date < ? AND replanned_for_date IS NULL)
-               OR replanned_for_date = ?)
-            ORDER BY is_delayed ASC, days_delayed DESC, created_at ASC
-            """;
-
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date, date);
-        logger.debug("Retrieved {} study goals (including delayed) for date: {}", goals.size(), date);
-        return goals;
+        return findByDate(date);
     }
 
-    /**
-     * Like {@link #findByDateIncludingDelayed(LocalDate)} but includes failed goals.
-     * Used by calendar view which shows all goals for each day.
-     */
     public static List<StudyGoal> findAllByDateIncludingDelayed(LocalDate date) {
-        if (jdbcTemplate == null || date == null) {
-            return List.of();
-        }
-
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE (date = ?
-               OR (is_delayed = TRUE AND achieved = FALSE AND failed = FALSE AND date < ? AND replanned_for_date IS NULL)
-               OR replanned_for_date = ?)
-            ORDER BY failed ASC, is_delayed ASC, days_delayed DESC, created_at ASC
-            """;
-
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date, date);
-        logger.debug("Retrieved {} study goals (all statuses, including delayed) for date: {}", goals.size(), date);
-        return goals;
+        return findAllByDate(date);
     }
-    
-    /**
-     * Get achieved study goals.
-     */
+
     public static List<StudyGoal> findAchieved() {
-        if (jdbcTemplate == null) {
-            throw new IllegalStateException("JdbcTemplate not initialized");
-        }
-        
-        String sql = "SELECT * FROM study_goals WHERE achieved = TRUE AND (failed = FALSE OR failed IS NULL) ORDER BY date DESC";
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper());
-        logger.debug("Retrieved {} achieved study goals", goals.size());
-        return goals;
+        requireJdbcTemplate();
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE a.outcome = 'ACHIEVED'
+            ORDER BY a.planned_for_date DESC, a.created_at DESC
+            """;
+        return jdbcTemplate.query(sql, getAttemptViewMapper());
     }
-    
-    /**
-     * Delete a study goal by ID (static method).
-     */
+
     public static boolean deleteById(String goalId) {
         if (jdbcTemplate == null || goalId == null) {
             return false;
         }
-        
-        String sql = "DELETE FROM study_goals WHERE id = ?";
-        int rowsAffected = jdbcTemplate.update(sql, goalId);
+        jdbcTemplate.update("DELETE FROM study_goal_attempts WHERE goal_id = ?", goalId);
+        int rowsAffected = jdbcTemplate.update("DELETE FROM study_goals WHERE id = ?", goalId);
         boolean deleted = rowsAffected > 0;
-        
         if (deleted) {
             logger.info("StudyGoal deleted: {}", goalId);
-        } else {
-            logger.warn("StudyGoal not found for deletion: {}", goalId);
         }
-        
         return deleted;
     }
-    
-    /**
-     * Get count of study goals by achievement status.
-     */
+
     public static long countByAchievement(boolean achieved) {
         if (jdbcTemplate == null) {
             return 0L;
         }
-        
-        String sql = "SELECT COUNT(*) FROM study_goals WHERE achieved = ? AND (failed = FALSE OR failed IS NULL)";
-        Integer count = jdbcTemplate.queryForObject(sql, Integer.class, achieved);
+        String outcome = achieved ? "ACHIEVED" : "PENDING";
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_goal_attempts WHERE outcome = ?",
+                Integer.class, outcome);
         return count != null ? count : 0L;
     }
-    
-    /**
-     * Find unachieved goals for a specific date (candidates for transfer).
-     */
+
     public static List<StudyGoal> findUnachievedByDate(LocalDate date) {
         if (jdbcTemplate == null || date == null) {
             return List.of();
         }
-        
-        String sql = "SELECT * FROM study_goals WHERE date = ? AND achieved = FALSE ORDER BY created_at";
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date);
-        logger.debug("Retrieved {} unachieved study goals for date: {}", goals.size(), date);
-        return goals;
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE a.planned_for_date = ?
+              AND a.outcome <> 'ACHIEVED'
+            ORDER BY a.created_at
+            """;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), date);
     }
-    
-    /**
-     * Find delayed goals (transferred from previous days).
-     */
+
     public static List<StudyGoal> findDelayed() {
-        if (jdbcTemplate == null) {
-            throw new IllegalStateException("JdbcTemplate not initialized");
-        }
-        
-        String sql = "SELECT * FROM study_goals WHERE is_delayed = TRUE ORDER BY days_delayed DESC, date DESC";
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper());
-        logger.debug("Retrieved {} delayed study goals", goals.size());
-        return goals;
+        requireJdbcTemplate();
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE a.outcome = 'MISSED'
+            ORDER BY a.planned_for_date DESC, a.created_at DESC
+            """;
+        return jdbcTemplate.query(sql, getAttemptViewMapper());
     }
-    
-    /**
-     * Find delayed goals for a specific date.
-     */
+
     public static List<StudyGoal> findDelayedByDate(LocalDate date) {
         if (jdbcTemplate == null || date == null) {
             return List.of();
         }
-        
-        String sql = "SELECT * FROM study_goals WHERE date = ? AND is_delayed = TRUE ORDER BY days_delayed DESC";
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date);
-        logger.debug("Retrieved {} delayed study goals for date: {}", goals.size(), date);
-        return goals;
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE a.planned_for_date = ?
+              AND a.outcome = 'MISSED'
+            ORDER BY a.created_at
+            """;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), date);
     }
-    
-    /**
-     * Find goals linked to a specific task for a given date, including delayed unachieved goals.
-     * Returns goals that are either planned for the date or delayed from earlier dates.
-     *
-     * @param taskId the task ID to find linked goals for
-     * @param date the date to scope the query
-     * @return list of study goals linked to the task for the given date context
-     */
+
     public static List<StudyGoal> findByTaskIdForDate(String taskId, LocalDate date) {
         if (jdbcTemplate == null || taskId == null || taskId.isBlank() || date == null) {
             return List.of();
         }
-
-        // Only return goals explicitly scheduled for this date or explicitly
-        // re-planned to it.  Do NOT auto-carry-forward delayed goals — those
-        // stay in the re-plan section until the user explicitly reschedules them.
-        // The old auto-carry-forward clause (is_delayed AND achieved = FALSE AND
-        // replanned_for_date IS NULL) caused two bugs:
-        //   1. Re-planning one goal made ALL delayed goals for the task appear
-        //   2. Achieved delayed goals vanished (achieved = TRUE no longer matched)
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE task_id = ?
-              AND (failed = FALSE OR failed IS NULL)
-              AND (date = ? OR replanned_for_date = ?)
-            ORDER BY is_delayed ASC, date ASC, created_at ASC
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE g.task_id = ?
+              AND g.status <> 'ABANDONED'
+              AND a.planned_for_date = ?
+              AND a.outcome IN ('PENDING', 'ACHIEVED')
+            ORDER BY a.outcome ASC, a.created_at ASC
             """;
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), taskId, date, date);
-        logger.debug("Retrieved {} goals for task {} on date {}", goals.size(), taskId, date);
-        return goals;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), taskId, date);
     }
 
-    /**
-     * Find ALL goals ever linked to a specific task, including failed ones.
-     * Used for the goal history view in the task management panel.
-     *
-     * @param taskId the task ID to find all linked goals for
-     * @return list of all study goals (active, achieved, failed) linked to the task, ordered by date desc
-     */
     public static List<StudyGoal> findByTaskId(String taskId) {
         if (jdbcTemplate == null || taskId == null || taskId.isBlank()) {
             return List.of();
         }
-
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE task_id = ?
-            ORDER BY date DESC, created_at DESC
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE g.task_id = ?
+            ORDER BY a.planned_for_date DESC, a.created_at DESC
             """;
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), taskId);
-        logger.debug("Retrieved {} total goals for task {}", goals.size(), taskId);
-        return goals;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), taskId);
     }
 
-    /**
-     * Batch-queries all (task_id, date) pairs that have at least one achieved
-     * goal within the given date range.  Returns a set of "taskId|date"
-     * strings for O(1) lookup.
-     *
-     * <p>This replaces per-cell calls to {@link #hasAchievedGoalForTask} in the
-     * calendar month view, eliminating an N+1 query storm.
-     *
-     * @param rangeStart inclusive start of the date range
-     * @param rangeEnd   inclusive end of the date range
-     * @return set of "taskId|date" keys where an achieved goal exists
-     */
-    public static java.util.Set<String> findAchievedTaskDatePairs(LocalDate rangeStart, LocalDate rangeEnd) {
+    public static Set<String> findAchievedTaskDatePairs(LocalDate rangeStart, LocalDate rangeEnd) {
         if (jdbcTemplate == null || rangeStart == null || rangeEnd == null) {
-            return java.util.Set.of();
+            return Set.of();
         }
         String sql = """
-            SELECT DISTINCT task_id, date FROM study_goals
-            WHERE achieved = TRUE
-              AND (failed = FALSE OR failed IS NULL)
-              AND task_id IS NOT NULL
-              AND date IS NOT NULL
-              AND date >= ? AND date <= ?
+            SELECT DISTINCT g.task_id, a.planned_for_date
+            FROM study_goals g
+            JOIN study_goal_attempts a ON a.goal_id = g.id
+            WHERE a.outcome = 'ACHIEVED'
+              AND g.task_id IS NOT NULL
+              AND a.planned_for_date >= ? AND a.planned_for_date <= ?
             """;
-        java.util.Set<String> result = new java.util.HashSet<>();
+        Set<String> result = new HashSet<>();
         jdbcTemplate.query(sql, (rs, rowNum) -> {
-            result.add(rs.getString("task_id") + "|" + rs.getDate("date").toLocalDate());
+            result.add(rs.getString("task_id") + "|" + rs.getDate("planned_for_date").toLocalDate());
             return null;
         }, rangeStart, rangeEnd);
         return result;
     }
 
-    /**
-     * Checks whether at least one achieved study goal exists for the given
-     * task on exactly the specified date.  Used to determine whether a
-     * recurring-task occurrence was "handled".
-     *
-     * @param taskId the task ID
-     * @param date   the exact occurrence date to check
-     * @return {@code true} if a linked, achieved goal exists for that date
-     */
     public static boolean hasAchievedGoalForTask(String taskId, LocalDate date) {
         if (jdbcTemplate == null || taskId == null || taskId.isBlank() || date == null) {
             return false;
         }
         String sql = """
-            SELECT COUNT(*) FROM study_goals
-            WHERE task_id = ? AND date = ? AND achieved = TRUE
-              AND (failed = FALSE OR failed IS NULL)
+            SELECT COUNT(*)
+            FROM study_goals g
+            JOIN study_goal_attempts a ON a.goal_id = g.id
+            WHERE g.task_id = ?
+              AND a.planned_for_date = ?
+              AND a.outcome = 'ACHIEVED'
             """;
         Integer count = jdbcTemplate.queryForObject(sql, Integer.class, taskId, date);
         return count != null && count > 0;
     }
-    
-    /**
-     * Find goals that are NOT linked to any task for a given date, including delayed unachieved ones.
-     *
-     * @param date the date to scope the query
-     * @return list of unlinked study goals for the given date context
-     */
+
     public static List<StudyGoal> findUnlinkedForDate(LocalDate date) {
         if (jdbcTemplate == null || date == null) {
             return List.of();
         }
-
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE task_id IS NULL
-              AND (failed = FALSE OR failed IS NULL)
-              AND (date = ? OR replanned_for_date = ?)
-            ORDER BY is_delayed ASC, date ASC, created_at ASC
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE g.task_id IS NULL
+              AND g.status <> 'ABANDONED'
+              AND a.planned_for_date = ?
+              AND a.outcome IN ('PENDING', 'ACHIEVED')
+            ORDER BY a.outcome ASC, a.created_at ASC
             """;
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper(), date, date);
-        logger.debug("Retrieved {} unlinked goals for date {}", goals.size(), date);
-        return goals;
+        return jdbcTemplate.query(sql, getAttemptViewMapper(), date);
     }
-    
-    /**
-     * Find all delayed, unachieved goals that have not yet been manually rescheduled.
-     * Used to populate the re-plan dropdown in the Study Planner.
-     *
-     * @return delayed goals eligible for manual rescheduling, ordered by delay severity
-     */
+
     public static List<StudyGoal> findDelayedAndNotReplanned() {
         if (jdbcTemplate == null) {
             return List.of();
         }
-        String sql = """
-            SELECT * FROM study_goals
-            WHERE is_delayed = TRUE
-              AND achieved = FALSE
-              AND (failed = FALSE OR failed IS NULL)
-              AND replanned_for_date IS NULL
-            ORDER BY days_delayed DESC, date ASC, created_at ASC
+        String sql = SELECT_ATTEMPT_VIEW + """
+            WHERE g.status = 'ACTIVE'
+              AND a.outcome = 'MISSED'
+              AND NOT EXISTS (
+                  SELECT 1 FROM study_goal_attempts p
+                  WHERE p.goal_id = g.id AND p.outcome = 'PENDING'
+              )
+              AND a.id = (
+                  SELECT latest.id
+                  FROM study_goal_attempts latest
+                  WHERE latest.goal_id = g.id
+                  ORDER BY latest.created_at DESC, latest.planned_for_date DESC
+                  LIMIT 1
+              )
+            ORDER BY a.planned_for_date ASC, a.created_at ASC
             """;
-        List<StudyGoal> goals = jdbcTemplate.query(sql, getRowMapper());
-        logger.debug("Retrieved {} delayed goals eligible for rescheduling", goals.size());
-        return goals;
+        return jdbcTemplate.query(sql, getAttemptViewMapper());
     }
 
-    /**
-     * RowMapper for converting database rows to StudyGoal objects.
-     */
-    private static RowMapper<StudyGoal> getRowMapper() {
-        return (rs, rowNum) -> {
-            String id = rs.getString("id");
-            LocalDate date = rs.getObject("date", LocalDate.class);
-            String description = rs.getString("description");
-            boolean achieved = rs.getBoolean("achieved");
-            String reasonIfNotAchieved = rs.getString("reason_if_not_achieved");
-            int daysDelayed = rs.getInt("days_delayed");
-            boolean isDelayed = rs.getBoolean("is_delayed");
-            int pointsDeducted = rs.getInt("points_deducted");
-            String taskId = rs.getString("task_id");
-            LocalDate replannedForDate = rs.getObject("replanned_for_date", LocalDate.class);
-            boolean failed = rs.getBoolean("failed");
+    public static int markPendingAttemptsBefore(LocalDate today) {
+        if (jdbcTemplate == null || today == null) {
+            return 0;
+        }
+        String sql = """
+            UPDATE study_goal_attempts
+            SET outcome = 'MISSED', outcome_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+            WHERE outcome = 'PENDING'
+              AND planned_for_date < ?
+            """;
+        return jdbcTemplate.update(sql, today);
+    }
 
-            return new StudyGoal(id, date, description, achieved, reasonIfNotAchieved,
-                               daysDelayed, isDelayed, pointsDeducted, taskId, replannedForDate, failed);
-        };
+    public static boolean createReplanAttempt(String goalId, LocalDate plannedForDate) {
+        if (jdbcTemplate == null || goalId == null || goalId.isBlank() || plannedForDate == null) {
+            return false;
+        }
+        Integer pendingCount = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*) FROM study_goal_attempts
+            WHERE goal_id = ? AND outcome = 'PENDING'
+            """, Integer.class, goalId);
+        if (pendingCount != null && pendingCount > 0) {
+            return false;
+        }
+
+        String latestAttemptId = jdbcTemplate.query("""
+            SELECT id FROM study_goal_attempts
+            WHERE goal_id = ?
+            ORDER BY created_at DESC, planned_for_date DESC
+            LIMIT 1
+            """, rs -> rs.next() ? rs.getString("id") : null, goalId);
+        if (latestAttemptId == null) {
+            return false;
+        }
+
+        String attemptId = UUID.randomUUID().toString();
+        int rows = jdbcTemplate.update("""
+            INSERT INTO study_goal_attempts (
+                id, goal_id, planned_for_date, replanned_from_attempt_id, outcome,
+                created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, 'PENDING', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            """, attemptId, goalId, plannedForDate, latestAttemptId);
+        jdbcTemplate.update("""
+            UPDATE study_goals
+            SET status = 'ACTIVE', achieved_attempt_id = NULL, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ? AND status = 'ACTIVE'
+            """, goalId);
+        return rows > 0;
+    }
+
+    public static boolean markCurrentAttemptAchieved(String goalId, String reasonIfNot) {
+        Optional<StudyGoal> goalOpt = findById(goalId);
+        if (goalOpt.isEmpty()) {
+            return false;
+        }
+        StudyGoal goal = goalOpt.get();
+        if (goal.attemptId == null) {
+            return false;
+        }
+        jdbcTemplate.update("""
+            UPDATE study_goal_attempts
+            SET outcome = 'ACHIEVED', reason_if_not_achieved = ?, outcome_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """, reasonIfNot, goal.attemptId);
+        jdbcTemplate.update("""
+            UPDATE study_goals
+            SET status = 'ACHIEVED', achieved_attempt_id = ?, achieved = TRUE, failed = FALSE,
+                reason_if_not_achieved = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """, goal.attemptId, reasonIfNot, goalId);
+        return true;
+    }
+
+    public static boolean reopenAchievedGoal(String goalId) {
+        if (jdbcTemplate == null || goalId == null || goalId.isBlank()) {
+            return false;
+        }
+        String achievedAttempt = jdbcTemplate.query("""
+            SELECT achieved_attempt_id FROM study_goals WHERE id = ?
+            """, rs -> rs.next() ? rs.getString("achieved_attempt_id") : null, goalId);
+        if (achievedAttempt == null) {
+            return false;
+        }
+        jdbcTemplate.update("""
+            UPDATE study_goal_attempts
+            SET outcome = 'PENDING', reason_if_not_achieved = NULL, outcome_at = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """, achievedAttempt);
+        jdbcTemplate.update("""
+            UPDATE study_goals
+            SET status = 'ACTIVE', achieved_attempt_id = NULL, achieved = FALSE,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """, goalId);
+        return true;
+    }
+
+    public static boolean abandonGoal(String goalId) {
+        Optional<StudyGoal> goalOpt = findById(goalId);
+        if (goalOpt.isEmpty()) {
+            return false;
+        }
+        StudyGoal goal = goalOpt.get();
+        if (goal.attemptId != null && goal.attemptOutcome == AttemptOutcome.PENDING) {
+            jdbcTemplate.update("""
+                UPDATE study_goal_attempts
+                SET outcome = 'MISSED', outcome_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """, goal.attemptId);
+        }
+        int rows = jdbcTemplate.update("""
+            UPDATE study_goals
+            SET status = 'ABANDONED', achieved_attempt_id = NULL, achieved = FALSE, failed = TRUE,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """, goalId);
+        return rows > 0;
+    }
+
+    private static RowMapper<StudyGoal> getAttemptViewMapper() {
+        return (rs, rowNum) -> new StudyGoal(
+                rs.getString("id"),
+                rs.getObject("planned_for_date", LocalDate.class),
+                rs.getString("description"),
+                rs.getString("task_id"),
+                parseGoalStatus(rs.getString("status")),
+                rs.getString("achieved_attempt_id"),
+                rs.getString("attempt_id"),
+                rs.getString("replanned_from_attempt_id"),
+                parseAttemptOutcome(rs.getString("attempt_outcome")),
+                rs.getString("reason_if_not_achieved"),
+                rs.getObject("outcome_at", LocalDateTime.class),
+                rs.getInt("attempt_number"),
+                rs.getInt("missed_attempt_count")
+        );
+    }
+
+    private static GoalStatus parseGoalStatus(String value) {
+        try {
+            return value == null ? GoalStatus.ACTIVE : GoalStatus.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return GoalStatus.ACTIVE;
+        }
+    }
+
+    private static AttemptOutcome parseAttemptOutcome(String value) {
+        try {
+            return value == null ? AttemptOutcome.PENDING : AttemptOutcome.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return AttemptOutcome.PENDING;
+        }
+    }
+
+    private static void requireJdbcTemplate() {
+        if (jdbcTemplate == null) {
+            throw new IllegalStateException("JdbcTemplate not initialized");
+        }
     }
 }

--- a/src/main/java/com/studysync/domain/entity/StudyGoal.java
+++ b/src/main/java/com/studysync/domain/entity/StudyGoal.java
@@ -758,6 +758,11 @@ public class StudyGoal {
             return false;
         }
         StudyGoal goal = goalOpt.get();
+        // An achieved goal cannot be abandoned: the ACHIEVED attempt row would
+        // survive and keep counting the occurrence as handled.
+        if (goal.status == GoalStatus.ACHIEVED) {
+            return false;
+        }
         if (goal.attemptId != null && goal.attemptOutcome == AttemptOutcome.PENDING) {
             jdbcTemplate.update("""
                 UPDATE study_goal_attempts

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -226,23 +226,41 @@ public class StudyService {
     }
 
     /**
-     * Reschedules a delayed goal to appear on today's date exactly once.
-     * The goal's achieved status is not changed. If the user does not complete
-     * it today it will not carry forward again — it is a one-shot reschedule.
+     * Returns active unlinked goals whose latest attempt was missed and which
+     * do not already have a pending attempt.
      *
-     * @param goalId ID of the goal to reschedule
+     * @return list of unlinked goals the user can choose to retry today
      */
-    public void replanGoalForToday(String goalId) {
-        StudyGoal.findById(goalId).ifPresent(goal -> {
-            if (goal.isAchieved()) {
-                return; // Already done
-            }
-            boolean created = StudyGoal.createReplanAttempt(goalId, dateTimeService.getCurrentDate());
-            if (created) {
-                markDirtyAndSaveLocally("study goal replan");
-                logger.info("Created new attempt for goal '{}' on {}", goal.getDescription(), dateTimeService.getCurrentDate());
-            }
-        });
+    @Transactional(readOnly = true)
+    public List<StudyGoal> getUnlinkedDelayedGoalsForReplanning() {
+        return StudyGoal.findDelayedAndNotReplanned().stream()
+                .filter(goal -> goal.getTaskId() == null || goal.getTaskId().isBlank())
+                .toList();
+    }
+
+    /**
+     * Creates a new pending attempt for an active missed goal on today's date.
+     * Achieved and abandoned goals are not retryable.
+     *
+     * @param goalId ID of the goal to retry
+     * @return {@code true} when a new pending retry attempt was created
+     */
+    public boolean replanGoalForToday(String goalId) {
+        Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
+        if (goalOpt.isEmpty()) {
+            logger.warn("Requested retry for study goal '{}' but it did not exist", goalId);
+            return false;
+        }
+        StudyGoal goal = goalOpt.get();
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED || goal.isAchieved()) {
+            return false;
+        }
+        boolean created = StudyGoal.createReplanAttempt(goalId, dateTimeService.getCurrentDate());
+        if (created) {
+            markDirtyAndSaveLocally("study goal replan");
+            logger.info("Created new attempt for goal '{}' on {}", goal.getDescription(), dateTimeService.getCurrentDate());
+        }
+        return created;
     }
 
     public boolean planGoalAttempt(String goalId, LocalDate plannedForDate) {
@@ -302,8 +320,8 @@ public class StudyService {
     }
 
     /**
-     * Soft-deletes a study goal by marking it as failed.
-     * The goal is preserved for historical display on its planned date.
+     * Abandons a study goal while preserving its attempt history for display.
+     * Abandoned goals are excluded from future retry planning.
      */
     public boolean markGoalAsFailed(String goalId) {
         if (goalId == null || goalId.isBlank()) {
@@ -458,17 +476,16 @@ public class StudyService {
             logger.info("Marked {} overdue study goal attempt(s) as MISSED", missedAttempts);
         }
 
-        return new GoalDelayProcessingResult(missedAttempts, 0);
+        return new GoalDelayProcessingResult(missedAttempts);
     }
 
     /**
      * Summary of overdue attempt processing.
      * @param missedAttempts number of pending attempts marked as missed
-     * @param abandonedGoals number of goals abandoned by this processing run
      */
-    public record GoalDelayProcessingResult(int missedAttempts, int abandonedGoals) {
+    public record GoalDelayProcessingResult(int missedAttempts) {
         public boolean hasChanges() {
-            return missedAttempts > 0 || abandonedGoals > 0;
+            return missedAttempts > 0;
         }
     }
     
@@ -486,22 +503,5 @@ public class StudyService {
     @Transactional(readOnly = true)
     public List<StudyGoal> getAllDelayedGoals() {
         return StudyGoal.findDelayed();
-    }
-    
-    @Transactional(readOnly = true)
-    public int getMissedGoalAttemptCount() {
-        return StudyGoal.findDelayed().size();
-    }
-
-    /**
-     * Returns the number of missed goal attempts.
-     *
-     * @deprecated Use {@link #getMissedGoalAttemptCount()}. The attempt-based
-     *             goal model no longer calculates delay penalty points.
-     */
-    @Deprecated
-    @Transactional(readOnly = true)
-    public int getTotalDelayPenaltyPoints() {
-        return getMissedGoalAttemptCount();
     }
 }

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -248,23 +247,22 @@ public class StudyService {
      */
     public void replanGoalForToday(String goalId) {
         StudyGoal.findById(goalId).ifPresent(goal -> {
-            if (goal.isAchieved() || goal.getReplannedForDate() != null) {
-                return; // Already done or already rescheduled
+            if (goal.isAchieved()) {
+                return; // Already done
             }
-            goal.setReplannedForDate(dateTimeService.getCurrentDate());
-            goal.save();
-            markDirtyAndSaveLocally("study goal replan");
-            logger.info("Rescheduled goal '{}' to appear today ({})", goal.getDescription(), dateTimeService.getCurrentDate());
+            boolean created = StudyGoal.createReplanAttempt(goalId, dateTimeService.getCurrentDate());
+            if (created) {
+                markDirtyAndSaveLocally("study goal replan");
+                logger.info("Created new attempt for goal '{}' on {}", goal.getDescription(), dateTimeService.getCurrentDate());
+            }
         });
     }
 
     public void updateStudyGoalAchievement(String goalId, boolean achieved, String reasonIfNot) {
-        Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
-        if (goalOpt.isPresent()) {
-            StudyGoal goal = goalOpt.get();
-            goal.setAchieved(achieved);
-            goal.setReasonIfNotAchieved(reasonIfNot);
-            goal.save();
+        boolean updated = achieved
+                ? StudyGoal.markCurrentAttemptAchieved(goalId, reasonIfNot)
+                : StudyGoal.reopenAchievedGoal(goalId);
+        if (updated) {
             markDirtyAndSaveLocally("study goal achievement update");
         }
     }
@@ -277,14 +275,10 @@ public class StudyService {
         if (goalId == null || goalId.isBlank()) {
             throw ValidationException.requiredFieldMissing("goalId");
         }
-        Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
-        if (goalOpt.isPresent()) {
-            StudyGoal goal = goalOpt.get();
-            goal.setFailed(true);
-            goal.setAchieved(false);
-            goal.save();
+        boolean abandoned = StudyGoal.abandonGoal(goalId);
+        if (abandoned) {
             markDirtyAndSaveLocally("study goal failure update");
-            logger.info("Marked study goal '{}' as failed", goalId);
+            logger.info("Abandoned study goal '{}'", goalId);
             return true;
         } else {
             logger.warn("Requested mark-as-failed for study goal '{}' but it did not exist", goalId);
@@ -423,85 +417,14 @@ public class StudyService {
      */
     public GoalDelayProcessingResult processAllDelayedGoals() {
         LocalDate today = dateTimeService.getCurrentDate();
-        List<StudyGoal> allGoals = StudyGoal.findAll();
-        int updatedGoals = 0;
-        int failedGoals = 0;
+        int missedAttempts = StudyGoal.markPendingAttemptsBefore(today);
 
-        for (StudyGoal goal : allGoals) {
-            // Skip if goal is achieved or already marked failed
-            if (goal.isAchieved() || goal.isFailed()) {
-                continue;
-            }
-
-            // Re-planned goals whose replan date has passed without being achieved
-            // must be marked as failed immediately — otherwise they vanish from all
-            // views (queries only match date or replanned_for_date equal to display date).
-            if (goal.getReplannedForDate() != null && goal.getReplannedForDate().isBefore(today)) {
-                String goalLabel = (goal.getDescription() != null && !goal.getDescription().isBlank())
-                        ? goal.getDescription()
-                        : goal.getId();
-                goal.setFailed(true);
-                goal.setDelayed(true);
-                int daysFromReplan = (int) ChronoUnit.DAYS.between(goal.getReplannedForDate(), today);
-                goal.setDaysDelayed(daysFromReplan);
-                goal.setPointsDeducted(calculateAccumulatedPenalty(daysFromReplan));
-                goal.save();
-                failedGoals++;
-                logger.info("Marked re-planned study goal '{}' as FAILED (replan date {} has passed)",
-                        goalLabel, goal.getReplannedForDate());
-                continue;
-            }
-
-            // Protect replanned goals on their replan date (user still has a chance today).
-            if (goal.getReplannedForDate() != null) {
-                continue;
-            }
-
-            // Check if goal date is in the past (delayed)
-            if (goal.getDate().isBefore(today)) {
-                int daysDelayed = (int) ChronoUnit.DAYS.between(goal.getDate(), today);
-                if (daysDelayed >= 14) {
-                    String goalLabel = (goal.getDescription() != null && !goal.getDescription().isBlank())
-                        ? goal.getDescription()
-                        : goal.getId();
-                    // Mark as failed instead of deleting — keeps history for logging
-                    goal.setFailed(true);
-                    goal.setDelayed(true);
-                    goal.setDaysDelayed(daysDelayed);
-                    goal.setPointsDeducted(calculateAccumulatedPenalty(daysDelayed));
-                    goal.save();
-                    failedGoals++;
-                    logger.info("Marked study goal '{}' as FAILED after {} days overdue",
-                            goalLabel, daysDelayed);
-                    continue;
-                }
-
-                int penalty = calculateAccumulatedPenalty(daysDelayed);
-
-                // Update goal with delay information
-                goal.setDelayed(true);
-                goal.setDaysDelayed(daysDelayed);
-                goal.setPointsDeducted(penalty);
-                goal.save();
-
-                updatedGoals++;
-            } else {
-                // Goal is not delayed - ensure delay flags are cleared
-                if (goal.isDelayed()) {
-                    goal.setDelayed(false);
-                    goal.setDaysDelayed(0);
-                    goal.setPointsDeducted(0);
-                    goal.save();
-                    updatedGoals++;
-                }
-            }
-        }
-
-        if (updatedGoals > 0 || failedGoals > 0) {
+        if (missedAttempts > 0) {
             markDirtyAndSaveLocally("delayed goal processing");
+            logger.info("Marked {} overdue study goal attempt(s) as MISSED", missedAttempts);
         }
 
-        return new GoalDelayProcessingResult(updatedGoals, failedGoals);
+        return new GoalDelayProcessingResult(missedAttempts, 0);
     }
 
     /**
@@ -549,7 +472,6 @@ public class StudyService {
      */
     @Transactional(readOnly = true)
     public int getTotalDelayPenaltyPoints() {
-        List<StudyGoal> delayedGoals = StudyGoal.findDelayed();
-        return delayedGoals.stream().mapToInt(StudyGoal::getPointsDeducted).sum();
+        return StudyGoal.findDelayed().size();
     }
 }

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -216,8 +216,13 @@ public class StudyService {
      * @return list of goals the user can choose to retry today
      */
     @Transactional(readOnly = true)
-    public List<StudyGoal> getDelayedGoalsForReplanning() {
-        return StudyGoal.findDelayedAndNotReplanned();
+    public List<StudyGoal> getDelayedGoalsForReplanning(final String taskId) {
+        if (taskId == null || taskId.isBlank()) {
+            return List.of();
+        }
+        return StudyGoal.findDelayedAndNotReplanned().stream()
+                .filter(goal -> taskId.equals(goal.getTaskId()))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -240,6 +240,53 @@ public class StudyService {
         });
     }
 
+    public boolean planGoalAttempt(String goalId, LocalDate plannedForDate) {
+        if (goalId == null || goalId.isBlank()) {
+            throw ValidationException.requiredFieldMissing("goalId");
+        }
+        if (plannedForDate == null) {
+            throw ValidationException.requiredFieldMissing("plannedForDate");
+        }
+        Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
+        if (goalOpt.isEmpty()) {
+            logger.warn("Requested retry for study goal '{}' but it did not exist", goalId);
+            return false;
+        }
+        StudyGoal goal = goalOpt.get();
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED || goal.isAchieved()) {
+            return false;
+        }
+        boolean created = StudyGoal.createReplanAttempt(goalId, plannedForDate);
+        if (created) {
+            markDirtyAndSaveLocally("study goal retry planning");
+            logger.info("Created new attempt for goal '{}' on {}", goal.getDescription(), plannedForDate);
+        }
+        return created;
+    }
+
+    public boolean updateStudyGoalDetails(String goalId, String description, LocalDate pendingPlannedForDate) {
+        if (goalId == null || goalId.isBlank()) {
+            throw ValidationException.requiredFieldMissing("goalId");
+        }
+        if (description == null || description.trim().isEmpty()) {
+            throw ValidationException.requiredFieldMissing("description");
+        }
+        Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
+        if (goalOpt.isEmpty()) {
+            logger.warn("Requested update for study goal '{}' but it did not exist", goalId);
+            return false;
+        }
+        StudyGoal goal = goalOpt.get();
+        if (goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING && pendingPlannedForDate == null) {
+            throw ValidationException.requiredFieldMissing("plannedForDate");
+        }
+        boolean updated = StudyGoal.updateDetails(goalId, description, pendingPlannedForDate);
+        if (updated) {
+            markDirtyAndSaveLocally("study goal details update");
+        }
+        return updated;
+    }
+
     public void updateStudyGoalAchievement(String goalId, boolean achieved, String reasonIfNot) {
         boolean updated = achieved
                 ? StudyGoal.markCurrentAttemptAchieved(goalId, reasonIfNot)

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -442,12 +442,12 @@ public class StudyService {
     // ================================================================
     
     /**
-     * Process all goals and update delay penalties for overdue goals.
-     * Only unachieved goals with dates in the past are considered delayed.
-     * Goals overdue by two weeks or more are marked as FAILED (never deleted).
-     * This should be called daily (e.g., via scheduled task or on app startup).
+     * Marks pending goal attempts planned before today as missed.
+     * This should be called daily, such as during startup, so overdue attempts
+     * become retryable without deleting the parent goal or applying legacy delay
+     * penalties.
      *
-     * @return summary of how many goals were updated or marked failed
+     * @return summary of how many pending attempts were marked missed
      */
     public GoalDelayProcessingResult processAllDelayedGoals() {
         LocalDate today = dateTimeService.getCurrentDate();
@@ -462,27 +462,14 @@ public class StudyService {
     }
 
     /**
-     * Summary of delayed-goal processing.
-     * @param updatedGoals number of existing goals updated with delay metadata
-     * @param failedGoals number of goals marked as failed because they exceeded the delay threshold
+     * Summary of overdue attempt processing.
+     * @param missedAttempts number of pending attempts marked as missed
+     * @param abandonedGoals number of goals abandoned by this processing run
      */
-    public record GoalDelayProcessingResult(int updatedGoals, int failedGoals) {
+    public record GoalDelayProcessingResult(int missedAttempts, int abandonedGoals) {
         public boolean hasChanges() {
-            return updatedGoals > 0 || failedGoals > 0;
+            return missedAttempts > 0 || abandonedGoals > 0;
         }
-    }
-    
-    /**
-     * Calculate accumulated penalty for delayed goals.
-     * Formula: 5 points for first delay, then 2 points per additional day.
-     * 
-     * @param totalDaysDelayed total days the goal has been delayed
-     * @return total penalty points
-     */
-    private int calculateAccumulatedPenalty(int totalDaysDelayed) {
-        if (totalDaysDelayed <= 0) return 0;
-        if (totalDaysDelayed == 1) return 5; // First delay
-        return 5 + (totalDaysDelayed - 1) * 2; // Additional days
     }
     
     /**
@@ -501,11 +488,20 @@ public class StudyService {
         return StudyGoal.findDelayed();
     }
     
+    @Transactional(readOnly = true)
+    public int getMissedGoalAttemptCount() {
+        return StudyGoal.findDelayed().size();
+    }
+
     /**
-     * Calculate total points deducted from delayed goals.
+     * Returns the number of missed goal attempts.
+     *
+     * @deprecated Use {@link #getMissedGoalAttemptCount()}. The attempt-based
+     *             goal model no longer calculates delay penalty points.
      */
+    @Deprecated
     @Transactional(readOnly = true)
     public int getTotalDelayPenaltyPoints() {
-        return StudyGoal.findDelayed().size();
+        return getMissedGoalAttemptCount();
     }
 }

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -209,33 +209,15 @@ public class StudyService {
     }
 
     /**
-     * Returns delayed, unachieved goals that are eligible for manual rescheduling
-     * to today. Goals linked to CANCELLED or POSTPONED tasks are excluded.
-     * Orphan goals (no task) are included so they remain visible and don't
-     * silently age into auto-deletion.
+     * Returns active goals whose latest attempt was missed and which do not
+     * already have a pending attempt. Task status is intentionally ignored here:
+     * the parent goal lifecycle is the source of truth for retry eligibility.
      *
-     * @return list of goals the user can choose to re-plan for today
+     * @return list of goals the user can choose to retry today
      */
     @Transactional(readOnly = true)
     public List<StudyGoal> getDelayedGoalsForReplanning() {
-        return StudyGoal.findDelayedAndNotReplanned().stream()
-                .filter(goal -> {
-                    // Orphan goals (no task) are eligible for rescheduling.
-                    // Without this, they become invisible in the planner and
-                    // silently auto-delete after 14 days.
-                    if (goal.getTaskId() == null || goal.getTaskId().isBlank()) {
-                        return true;
-                    }
-                    // NOTE: Do NOT filter out goals whose task is already visible
-                    // today. findByTaskIdForDate() no longer auto-carries forward
-                    // delayed goals, so if we also exclude them here, they become
-                    // unreachable and silently age into auto-deletion.
-                    return Task.findById(goal.getTaskId())
-                            .map(task -> task.getStatus() != TaskStatus.CANCELLED
-                                      && task.getStatus() != TaskStatus.POSTPONED)
-                            .orElse(false);
-                })
-                .collect(Collectors.toList());
+        return StudyGoal.findDelayedAndNotReplanned();
     }
 
     /**

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -270,6 +270,10 @@ public class StudyService {
         if (plannedForDate == null) {
             throw ValidationException.requiredFieldMissing("plannedForDate");
         }
+        if (plannedForDate.isBefore(dateTimeService.getCurrentDate())) {
+            throw ValidationException.invalidDateRange(
+                plannedForDate.toString(), "today or a future date");
+        }
         Optional<StudyGoal> goalOpt = StudyGoal.findById(goalId);
         if (goalOpt.isEmpty()) {
             logger.warn("Requested retry for study goal '{}' but it did not exist", goalId);
@@ -333,7 +337,7 @@ public class StudyService {
             logger.info("Abandoned study goal '{}'", goalId);
             return true;
         } else {
-            logger.warn("Requested mark-as-failed for study goal '{}' but it did not exist", goalId);
+            logger.warn("Requested mark-as-failed for study goal '{}' but it did not exist or was achieved", goalId);
             return false;
         }
     }

--- a/src/main/java/com/studysync/domain/service/TaskService.java
+++ b/src/main/java/com/studysync/domain/service/TaskService.java
@@ -377,8 +377,6 @@ public class TaskService {
     public List<Task> getTasksForDate(LocalDate date) {
         if (date == null) return List.of();
 
-        LocalDate today = dateTimeService.getCurrentDate();
-
         // Fetch all tasks once and index by ID so the goal-linking pass below
         // can look up tasks without extra DB round-trips.
         List<Task> allTasks = Task.findAll();
@@ -387,43 +385,7 @@ public class TaskService {
                         (existing, replacement) -> existing));
 
         List<Task> result = allTasks.stream()
-            .filter(task -> {
-                TaskStatus s = task.getStatus();
-                boolean isActive = s == TaskStatus.OPEN || s == TaskStatus.IN_PROGRESS;
-                // POSTPONED and CANCELLED tasks are excluded from the daily
-                // planner — only DELAYED tasks surface alongside active ones.
-                boolean isPending = s == TaskStatus.DELAYED;
-
-                if (task.isRecurring()) {
-                    // Start date on a recurring task means "don't appear before this date"
-                    if (task.getStartDate() != null && date.isBefore(task.getStartDate())) {
-                        return false;
-                    }
-                    // Deadline on a recurring task means "stop recurring after this date"
-                    if (task.getDeadline() != null && date.isAfter(task.getDeadline())) {
-                        return false;
-                    }
-                    // Reference Monday is derived from the task's recurrence
-                    // anchor (startDate if set, otherwise createdAt), so that
-                    // multi-week intervals are measured consistently.
-                    LocalDate anchorMonday = task.getRecurrenceAnchor()
-                            .with(TemporalAdjusters
-                                    .previousOrSame(DayOfWeek.MONDAY));
-                    return isActive && recurringTaskAppliesTo(task, date, anchorMonday);
-                }
-
-                // Non-recurring: must be unresolved
-                if (!(isActive || isPending)) return false;
-
-                LocalDate deadline = task.getDeadline();
-                if (deadline == null) {
-                    // Undated tasks only surface for today
-                    return date.equals(today);
-                }
-                // Tasks with a deadline: show on the due date and every day after
-                // (so overdue tasks remain visible until resolved)
-                return !date.isBefore(deadline);
-            })
+            .filter(task -> taskSurfacesOn(task, date))
             .collect(Collectors.toCollection(ArrayList::new));
 
         // Also include IN_PROGRESS or DELAYED tasks that have a goal planned for
@@ -452,7 +414,57 @@ public class TaskService {
 
         return result;
     }
-    
+
+    /**
+     * Decides whether a task surfaces in the daily planner for the given date
+     * based on its status, deadline, and recurrence rules alone (goal-linked
+     * inclusion is handled separately by {@link #getTasksForDate}).
+     *
+     * @param task the task to test; {@code null} returns {@code false}
+     * @param date the planner date; {@code null} returns {@code false}
+     * @return {@code true} if the task should appear on that date
+     */
+    public boolean taskSurfacesOn(Task task, LocalDate date) {
+        if (task == null || date == null) {
+            return false;
+        }
+        TaskStatus s = task.getStatus();
+        boolean isActive = s == TaskStatus.OPEN || s == TaskStatus.IN_PROGRESS;
+        // POSTPONED and CANCELLED tasks are excluded from the daily
+        // planner — only DELAYED tasks surface alongside active ones.
+        boolean isPending = s == TaskStatus.DELAYED;
+
+        if (task.isRecurring()) {
+            // Start date on a recurring task means "don't appear before this date"
+            if (task.getStartDate() != null && date.isBefore(task.getStartDate())) {
+                return false;
+            }
+            // Deadline on a recurring task means "stop recurring after this date"
+            if (task.getDeadline() != null && date.isAfter(task.getDeadline())) {
+                return false;
+            }
+            // Reference Monday is derived from the task's recurrence
+            // anchor (startDate if set, otherwise createdAt), so that
+            // multi-week intervals are measured consistently.
+            LocalDate anchorMonday = task.getRecurrenceAnchor()
+                    .with(TemporalAdjusters
+                            .previousOrSame(DayOfWeek.MONDAY));
+            return isActive && recurringTaskAppliesTo(task, date, anchorMonday);
+        }
+
+        // Non-recurring: must be unresolved
+        if (!(isActive || isPending)) return false;
+
+        LocalDate deadline = task.getDeadline();
+        if (deadline == null) {
+            // Undated tasks only surface for today
+            return date.equals(dateTimeService.getCurrentDate());
+        }
+        // Tasks with a deadline: show on the due date and every day after
+        // (so overdue tasks remain visible until resolved)
+        return !date.isBefore(deadline);
+    }
+
     public boolean isHealthy() {
         try {
             Task.findAll();

--- a/src/main/java/com/studysync/domain/service/TaskService.java
+++ b/src/main/java/com/studysync/domain/service/TaskService.java
@@ -651,7 +651,7 @@ public class TaskService {
             }
 
             if (recurringTaskAppliesTo(task, yesterday, anchorMonday)
-                    && !StudyGoal.hasAchievedGoalForTask(task.getId(), yesterday)) {
+                    && !StudyGoal.hasHandledGoalForTaskOccurrence(task.getId(), yesterday)) {
                 result.add(new MissedOccurrence(task, yesterday));
             }
         }
@@ -668,6 +668,6 @@ public class TaskService {
      * @return {@code true} if the occurrence was handled
      */
     public boolean isOccurrenceHandled(Task task, LocalDate date) {
-        return StudyGoal.hasAchievedGoalForTask(task.getId(), date);
+        return StudyGoal.hasHandledGoalForTaskOccurrence(task.getId(), date);
     }
 }

--- a/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
+++ b/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
@@ -282,9 +282,6 @@ public class StudySyncUI {
             if (result.missedAttempts() > 0) {
                 logger.info("Marked {} overdue study goal attempt(s) as missed", result.missedAttempts());
             }
-            if (result.abandonedGoals() > 0) {
-                logger.info("Abandoned {} study goal(s)", result.abandonedGoals());
-            }
         } catch (Exception e) {
             logger.error("Failed to process delayed goals on startup", e);
         }

--- a/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
+++ b/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
@@ -280,10 +280,10 @@ public class StudySyncUI {
         try {
             StudyService.GoalDelayProcessingResult result = studyService.processAllDelayedGoals();
             if (result.updatedGoals() > 0) {
-                logger.info("Updated delay status for {} study goals carried over from previous days", result.updatedGoals());
+                logger.info("Marked {} overdue study goal attempt(s) as missed", result.updatedGoals());
             }
             if (result.failedGoals() > 0) {
-                logger.info("Marked {} study goals as FAILED (overdue by at least two weeks)", result.failedGoals());
+                logger.info("Abandoned {} study goal(s)", result.failedGoals());
             }
         } catch (Exception e) {
             logger.error("Failed to process delayed goals on startup", e);

--- a/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
+++ b/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
@@ -279,11 +279,11 @@ public class StudySyncUI {
     private void processDelayedGoalsOnStartup() {
         try {
             StudyService.GoalDelayProcessingResult result = studyService.processAllDelayedGoals();
-            if (result.updatedGoals() > 0) {
-                logger.info("Marked {} overdue study goal attempt(s) as missed", result.updatedGoals());
+            if (result.missedAttempts() > 0) {
+                logger.info("Marked {} overdue study goal attempt(s) as missed", result.missedAttempts());
             }
-            if (result.failedGoals() > 0) {
-                logger.info("Abandoned {} study goal(s)", result.failedGoals());
+            if (result.abandonedGoals() > 0) {
+                logger.info("Abandoned {} study goal(s)", result.abandonedGoals());
             }
         } catch (Exception e) {
             logger.error("Failed to process delayed goals on startup", e);

--- a/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
+++ b/src/main/java/com/studysync/presentation/ui/StudySyncUI.java
@@ -100,7 +100,7 @@ public class StudySyncUI {
         Tab tasksTab = new Tab("Tasks");
         tasksTab.setGraphic(TaskStyleUtils.iconLabel("\u2611", 14));
         panels.put(tasksTab, new TaskManagementPanel(this.taskService, this.categoryService, this.reminderService,
-                this::showModal, this::closeModal));
+                this.studyService, this::showModal, this::closeModal));
         panelMap = Collections.unmodifiableMap(panels);
     }
 

--- a/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
@@ -234,15 +234,15 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         int row = 0;
         int col = startCol;
 
-        // Batch-query all achieved (task, date) pairs for the visible month
+        // Batch-query all handled (task, date) pairs for the visible month
         // to avoid an N+1 SQL query per recurring task per day cell.
         LocalDate monthStart = currentMonth.atDay(1);
         LocalDate monthEnd = currentMonth.atEndOfMonth();
-        java.util.Set<String> achievedPairs = StudyGoal.findAchievedTaskDatePairs(monthStart, monthEnd);
+        java.util.Set<String> handledPairs = StudyGoal.findHandledTaskDatePairs(monthStart, monthEnd);
 
         for (int day = 1; day <= daysInMonth; day++) {
             LocalDate date = currentMonth.atDay(day);
-            VBox dayCell = createDayCell(date, achievedPairs);
+            VBox dayCell = createDayCell(date, handledPairs);
 
             calendarGrid.add(dayCell, col, row);
 
@@ -254,7 +254,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         }
     }
 
-    private VBox createDayCell(LocalDate date, java.util.Set<String> achievedPairs) {
+    private VBox createDayCell(LocalDate date, java.util.Set<String> handledPairs) {
         VBox dayCell = new VBox(5);
         dayCell.setPrefSize(CELL_WIDTH, CELL_HEIGHT);
         dayCell.setPadding(new Insets(8));
@@ -346,7 +346,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             if (date.isBefore(today)) {
                 missedCount = dayData.tasks.stream()
                         .filter(Task::isRecurring)
-                        .filter(t -> !achievedPairs.contains(t.getId() + "|" + date))
+                        .filter(t -> !handledPairs.contains(t.getId() + "|" + date))
                         .count();
             }
             long handledRecurring = dayData.tasks.stream().filter(Task::isRecurring).count() - missedCount;
@@ -861,7 +861,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             } else if (TaskStyleUtils.isDueToday(task, date)) {
                 headerRow.getChildren().add(TaskStyleUtils.createDueTodayBadge());
             } else if (task.isRecurring() && date.isBefore(LocalDate.now())
-                       && !StudyGoal.hasAchievedGoalForTask(task.getId(), date)) {
+                       && !StudyGoal.hasHandledGoalForTaskOccurrence(task.getId(), date)) {
                 headerRow.getChildren().add(TaskStyleUtils.createMissedBadge());
                 // Red border for missed recurring occurrence
                 taskBox.setStyle("-fx-background-color: white; -fx-background-radius: 8;" +

--- a/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
@@ -1047,13 +1047,13 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         String statusText;
         if (goal.isFailed()) {
             statusIcon = "\u2715";
-            statusText = "Failed";
+            statusText = goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned" : "Missed";
         } else if (goal.isAchieved()) {
             statusIcon = "\u2705";
             statusText = "Achieved";
         } else if (goal.isDelayed()) {
             statusIcon = "[!] ";
-            statusText = "Delayed";
+            statusText = "Attempt " + goal.getAttemptNumber();
         } else {
             statusIcon = "\u25CB";
             statusText = "Pending";
@@ -1073,8 +1073,10 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
 
         // Add delay info if applicable
         if (goal.isDelayed()) {
-            Label delayLabel = new Label(String.format("» Originally from: %s • \u2668 %d days delayed",
-                goal.getDate().toString(), goal.getDaysDelayed()));
+            Label delayLabel = new Label(String.format("» Attempt %d • %d prior miss%s",
+                goal.getAttemptNumber(),
+                goal.getMissedAttemptCount(),
+                goal.getMissedAttemptCount() == 1 ? "" : "es"));
             TaskStyleUtils.fontNormal(delayLabel, 11);
             delayLabel.setTextFill(Color.web("#ff5722"));
             goalBox.getChildren().add(delayLabel);
@@ -1084,17 +1086,18 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         HBox actionBox = new HBox(8);
         actionBox.setAlignment(Pos.CENTER_RIGHT);
 
-        // "Mark as Failed" button — soft-delete (only for active goals)
+        // "Abandon" button — keeps the attempt timeline but stops future replanning.
         if (!goal.isAchieved() && !goal.isFailed()) {
-            Button failBtn = new Button("Mark as Failed");
+            Button failBtn = new Button("Abandon Goal");
             failBtn.setGraphic(TaskStyleUtils.iconLabel("\u2716", 12));
             failBtn.getStyleClass().addAll("btn-warning", "btn-small");
             failBtn.setOnAction(e -> {
                 Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
                 confirmation.initOwner(goalBox.getScene() != null ? goalBox.getScene().getWindow() : null);
-                confirmation.setTitle("Mark Goal as Failed");
-                confirmation.setHeaderText("Mark this goal as failed?");
-                confirmation.setContentText("The goal will be kept in history as failed.\nGoal: " + goal.getDescription());
+                confirmation.setTitle("Abandon Study Goal");
+                confirmation.setHeaderText("Abandon this goal?");
+                confirmation.setContentText("The goal will stop appearing for re-planning, but its attempt history will be kept.\nGoal: "
+                        + goal.getDescription());
 
                 confirmation.showAndWait().ifPresent(response -> {
                     if (response == ButtonType.OK) {

--- a/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
@@ -632,8 +632,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         metricsGrid.add(new Label("Points Earned:"), 0, 2);
         metricsGrid.add(new Label(String.valueOf(dayData.totalPoints)), 1, 2);
         
-        // Goals
-        metricsGrid.add(new Label("Goals Achieved:"), 0, 3);
+        // Goal attempts
+        metricsGrid.add(new Label("Attempts Achieved:"), 0, 3);
         metricsGrid.add(new Label(dayData.achievedGoals + "/" + dayData.totalGoals), 1, 3);
         
         // Tasks
@@ -708,7 +708,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             HBox headerBox = new HBox(15);
             headerBox.setAlignment(Pos.CENTER_LEFT);
             
-            Button addGoalBtn = new Button("+ Add Study Goal");
+            Button addGoalBtn = new Button("+ Add Goal Attempt");
             addGoalBtn.getStyleClass().add("btn-purple");
             addGoalBtn.setStyle("-fx-font-size: 12px; -fx-padding: 8 16;");
             addGoalBtn.setOnAction(e -> {
@@ -729,8 +729,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         
         if (studyGoals.isEmpty()) {
             String emptyMessage = isFutureDate
-                ? "No goals planned yet. Click the button above to plan ahead!"
-                : "No goals recorded for this date";
+                ? "No goal attempts planned yet. Click the button above to plan ahead!"
+                : "No goal attempts recorded for this date";
             Label noGoalsLabel = new Label(emptyMessage);
             noGoalsLabel.setGraphic(TaskStyleUtils.iconLabel(isFutureDate ? "\u25C6" : "\u25CB", 14));
             TaskStyleUtils.fontNormal(noGoalsLabel, 14);
@@ -741,7 +741,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             return content;
         }
         
-        Label goalsTitle = new Label("\u25CE Study Goals (" + studyGoals.size() + ")");
+        Label goalsTitle = new Label("\u25CE Study Goal Attempts (" + studyGoals.size() + ")");
         TaskStyleUtils.fontBold(goalsTitle, 18);
         goalsTitle.setTextFill(Color.web("#9b59b6"));
         content.getChildren().add(goalsTitle);
@@ -945,7 +945,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         // Goal achievement analysis
         if (dayData.totalGoals > 0) {
             double goalCompletionRate = ((double) dayData.achievedGoals / dayData.totalGoals) * 100;
-            Label goalAnalysis = new Label(String.format("Goal Completion: %.0f%% (%d out of %d goals achieved)", 
+            Label goalAnalysis = new Label(String.format("Attempt Completion: %.0f%% (%d out of %d attempts achieved)",
                 goalCompletionRate, dayData.achievedGoals, dayData.totalGoals));
             TaskStyleUtils.fontNormal(goalAnalysis, 12);
             goalAnalysis.setTextFill(goalCompletionRate == 100 ? Color.web("#27ae60") : Color.web("#e74c3c"));
@@ -983,7 +983,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             }
             
             if (dayData.totalGoals > 0 && dayData.achievedGoals < dayData.totalGoals) {
-                recommendations.getChildren().add(createRecommendationLabel("• Some goals were not achieved - review and adjust goal difficulty"));
+                recommendations.getChildren().add(createRecommendationLabel("• Some attempts were missed - review and adjust goal difficulty"));
             }
             
             if (dayData.productivityScore >= 80) {
@@ -1047,16 +1047,16 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         String statusText;
         if (goal.isFailed()) {
             statusIcon = "\u2715";
-            statusText = goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned" : "Missed";
+            statusText = goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned Goal" : "Missed Attempt";
         } else if (goal.isAchieved()) {
             statusIcon = "\u2705";
-            statusText = "Achieved";
+            statusText = "Achieved Attempt";
         } else if (goal.isDelayed()) {
             statusIcon = "[!] ";
-            statusText = "Attempt " + goal.getAttemptNumber();
+            statusText = "Retry Attempt";
         } else {
             statusIcon = "\u25CB";
-            statusText = "Pending";
+            statusText = "Pending Attempt";
         }
 
         Label statusLabel = new Label(statusIcon + " " + statusText);
@@ -1069,18 +1069,11 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         TaskStyleUtils.fontNormal(descriptionLabel, 13);
         descriptionLabel.setWrapText(true);
 
-        goalBox.getChildren().addAll(statusLabel, descriptionLabel);
+        Label attemptLabel = new Label(formatGoalAttemptSummary(goal));
+        TaskStyleUtils.fontNormal(attemptLabel, 11);
+        attemptLabel.setTextFill(goal.getMissedAttemptCount() > 0 ? Color.web("#ff5722") : Color.web("#6c757d"));
 
-        // Add delay info if applicable
-        if (goal.isDelayed()) {
-            Label delayLabel = new Label(String.format("» Attempt %d • %d prior miss%s",
-                goal.getAttemptNumber(),
-                goal.getMissedAttemptCount(),
-                goal.getMissedAttemptCount() == 1 ? "" : "es"));
-            TaskStyleUtils.fontNormal(delayLabel, 11);
-            delayLabel.setTextFill(Color.web("#ff5722"));
-            goalBox.getChildren().add(delayLabel);
-        }
+        goalBox.getChildren().addAll(statusLabel, descriptionLabel, attemptLabel);
 
         // Action buttons
         HBox actionBox = new HBox(8);
@@ -1133,6 +1126,14 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         goalBox.getChildren().add(actionBox);
 
         return goalBox;
+    }
+
+    private String formatGoalAttemptSummary(StudyGoal goal) {
+        String summary = "Attempt " + goal.getAttemptNumber() + " planned for " + goal.getDate();
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
+            summary += " | parent abandoned";
+        }
+        return summary;
     }
     
     private VBox createStudySessionBox(StudySession session) {
@@ -1265,8 +1266,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         dialog.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
         boolean isFutureDate = date.isAfter(LocalDate.now());
         
-        dialog.setTitle(isFutureDate ? "Plan Study Goal" : "Add Study Goal");
-        dialog.setHeaderText("Add a study goal for " + date.format(DateTimeFormatter.ofPattern("EEEE, MMMM dd, yyyy")));
+        dialog.setTitle(isFutureDate ? "Plan Goal Attempt" : "Add Goal Attempt");
+        dialog.setHeaderText("Add a goal attempt for " + date.format(DateTimeFormatter.ofPattern("EEEE, MMMM dd, yyyy")));
         
         DialogPane dialogPane = dialog.getDialogPane();
         dialogPane.getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
@@ -1275,8 +1276,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         content.setPadding(new Insets(20));
         
         Label instructionLabel = new Label(isFutureDate 
-            ? "Plan what you want to achieve on this day:"
-            : "What do you want to achieve today?");
+            ? "Plan what you want to attempt on this day:"
+            : "What do you want to attempt today?");
         TaskStyleUtils.fontNormal(instructionLabel, 12);
         
         TextArea goalTextArea = new TextArea();
@@ -1310,10 +1311,10 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
                     // Show confirmation
                     Alert successAlert = new Alert(Alert.AlertType.INFORMATION);
                     successAlert.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
-                    successAlert.setTitle("Goal Added");
+                    successAlert.setTitle("Goal Attempt Added");
                     successAlert.setHeaderText(null);
-                    successAlert.setContentText("Study goal added successfully for " + 
-                        date.format(DateTimeFormatter.ofPattern("MMMM dd, yyyy")));
+                    successAlert.setContentText("Goal attempt added successfully for "
+                        + date.format(DateTimeFormatter.ofPattern("MMMM dd, yyyy")));
                     successAlert.showAndWait();
                 } catch (Exception e) {
                     Alert errorAlert = new Alert(Alert.AlertType.ERROR);

--- a/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/CalendarViewPanel.java
@@ -708,7 +708,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             HBox headerBox = new HBox(15);
             headerBox.setAlignment(Pos.CENTER_LEFT);
             
-            Button addGoalBtn = new Button("+ Add Goal Attempt");
+            Button addGoalBtn = new Button("+ Add Goal");
             addGoalBtn.getStyleClass().add("btn-purple");
             addGoalBtn.setStyle("-fx-font-size: 12px; -fx-padding: 8 16;");
             addGoalBtn.setOnAction(e -> {
@@ -729,8 +729,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         
         if (studyGoals.isEmpty()) {
             String emptyMessage = isFutureDate
-                ? "No goal attempts planned yet. Click the button above to plan ahead!"
-                : "No goal attempts recorded for this date";
+                ? "No goals planned yet. Click the button above to plan ahead!"
+                : "No goals recorded for this date";
             Label noGoalsLabel = new Label(emptyMessage);
             noGoalsLabel.setGraphic(TaskStyleUtils.iconLabel(isFutureDate ? "\u25C6" : "\u25CB", 14));
             TaskStyleUtils.fontNormal(noGoalsLabel, 14);
@@ -741,7 +741,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             return content;
         }
         
-        Label goalsTitle = new Label("\u25CE Study Goal Attempts (" + studyGoals.size() + ")");
+        Label goalsTitle = new Label("\u25CE Study Goals (" + studyGoals.size() + ")");
         TaskStyleUtils.fontBold(goalsTitle, 18);
         goalsTitle.setTextFill(Color.web("#9b59b6"));
         content.getChildren().add(goalsTitle);
@@ -945,7 +945,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         // Goal achievement analysis
         if (dayData.totalGoals > 0) {
             double goalCompletionRate = ((double) dayData.achievedGoals / dayData.totalGoals) * 100;
-            Label goalAnalysis = new Label(String.format("Attempt Completion: %.0f%% (%d out of %d attempts achieved)",
+            Label goalAnalysis = new Label(String.format("Goal Completion: %.0f%% (%d out of %d goals achieved)",
                 goalCompletionRate, dayData.achievedGoals, dayData.totalGoals));
             TaskStyleUtils.fontNormal(goalAnalysis, 12);
             goalAnalysis.setTextFill(goalCompletionRate == 100 ? Color.web("#27ae60") : Color.web("#e74c3c"));
@@ -983,7 +983,7 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
             }
             
             if (dayData.totalGoals > 0 && dayData.achievedGoals < dayData.totalGoals) {
-                recommendations.getChildren().add(createRecommendationLabel("• Some attempts were missed - review and adjust goal difficulty"));
+                recommendations.getChildren().add(createRecommendationLabel("• Some goals were missed - review and adjust goal difficulty"));
             }
             
             if (dayData.productivityScore >= 80) {
@@ -1047,16 +1047,16 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         String statusText;
         if (goal.isFailed()) {
             statusIcon = "\u2715";
-            statusText = goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned Goal" : "Missed Attempt";
+            statusText = goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned Goal" : "Missed Goal";
         } else if (goal.isAchieved()) {
             statusIcon = "\u2705";
-            statusText = "Achieved Attempt";
+            statusText = "Achieved Goal";
         } else if (goal.isDelayed()) {
             statusIcon = "[!] ";
-            statusText = "Retry Attempt";
+            statusText = "Retry Goal";
         } else {
             statusIcon = "\u25CB";
-            statusText = "Pending Attempt";
+            statusText = "Pending Goal";
         }
 
         Label statusLabel = new Label(statusIcon + " " + statusText);
@@ -1266,8 +1266,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         dialog.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
         boolean isFutureDate = date.isAfter(LocalDate.now());
         
-        dialog.setTitle(isFutureDate ? "Plan Goal Attempt" : "Add Goal Attempt");
-        dialog.setHeaderText("Add a goal attempt for " + date.format(DateTimeFormatter.ofPattern("EEEE, MMMM dd, yyyy")));
+        dialog.setTitle(isFutureDate ? "Plan Goal" : "Add Goal");
+        dialog.setHeaderText("Add a goal for " + date.format(DateTimeFormatter.ofPattern("EEEE, MMMM dd, yyyy")));
         
         DialogPane dialogPane = dialog.getDialogPane();
         dialogPane.getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
@@ -1276,8 +1276,8 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
         content.setPadding(new Insets(20));
         
         Label instructionLabel = new Label(isFutureDate 
-            ? "Plan what you want to attempt on this day:"
-            : "What do you want to attempt today?");
+            ? "Plan what you want to study on this day:"
+            : "What do you want to study today?");
         TaskStyleUtils.fontNormal(instructionLabel, 12);
         
         TextArea goalTextArea = new TextArea();
@@ -1311,9 +1311,9 @@ public class CalendarViewPanel extends ScrollPane implements RefreshablePanel {
                     // Show confirmation
                     Alert successAlert = new Alert(Alert.AlertType.INFORMATION);
                     successAlert.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
-                    successAlert.setTitle("Goal Attempt Added");
+                    successAlert.setTitle("Goal Added");
                     successAlert.setHeaderText(null);
-                    successAlert.setContentText("Goal attempt added successfully for "
+                    successAlert.setContentText("Goal added successfully for "
                         + date.format(DateTimeFormatter.ofPattern("MMMM dd, yyyy")));
                     successAlert.showAndWait();
                 } catch (Exception e) {

--- a/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
@@ -596,9 +596,11 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         TaskStyleUtils.fontNormal(dateLabel, 11);
         dateLabel.setTextFill(Color.web("#7f8c8d"));
         
-        // Show if it was delayed before achievement
+        // Show attempt history if achievement followed one or more misses.
         if (goal.isDelayed()) {
-            Label delayLabel = new Label("[!]  Delayed " + goal.getDaysDelayed() + " day(s)");
+            Label delayLabel = new Label("[!]  Attempt " + goal.getAttemptNumber()
+                    + " after " + goal.getMissedAttemptCount() + " miss"
+                    + (goal.getMissedAttemptCount() == 1 ? "" : "es"));
             TaskStyleUtils.fontNormal(delayLabel, 11);
             delayLabel.setTextFill(Color.web("#e67e22"));
             detailsBox.getChildren().addAll(dateLabel, delayLabel);
@@ -665,8 +667,8 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
                 recentSessions.stream().mapToInt(StudySession::getFocusLevel).average().orElse(0);
 
             int achievedGoals = (int) recentGoals.stream().filter(StudyGoal::isAchieved).count();
-            int totalGoals = recentGoals.size();
-            double goalCompletionRate = totalGoals > 0 ? (double) achievedGoals / totalGoals * 100 : 0;
+            int missedGoals = (int) recentGoals.stream().filter(StudyGoal::isFailed).count();
+            int goalAttemptScore = achievedGoals - missedGoals;
             
             long completedTasks = allTasks.stream().filter(t -> t.getStatus() == TaskStatus.COMPLETED).count();
             long totalActiveTasks = allTasks.stream().filter(t -> t.getStatus() != TaskStatus.COMPLETED).count();
@@ -685,7 +687,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
             HBox row2 = new HBox(15);
             row2.setAlignment(Pos.CENTER);
             
-            VBox goalsCard = createStatCard("Goal Rate", String.format("%.0f%%", goalCompletionRate), "Goals achieved", "#27ae60");
+            VBox goalsCard = createStatCard("Goal Score", String.format("%+d", goalAttemptScore), "Achieved minus missed attempts", "#27ae60");
             VBox tasksCard = createStatCard("Tasks Done", String.valueOf(completedTasks), "Completed tasks", "#16a085");
             VBox efficiencyCard = createStatCard("Efficiency", 
                 totalMinutes > 0 ? String.format("%.1f", (double) totalPoints / totalMinutes * 60) : "0", 
@@ -875,14 +877,16 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         double avgMinutesPerDay = totalMinutes / 30.0;
         double volumeScore = Math.min(1.0, avgMinutesPerDay / 120.0) * 20; // 2 hours per day = max score
         
-        // Goal achievement score (10% weight) — failed/delayed goals count against the rate
+        // Goal attempt score (10% weight): achieved attempts help, missed attempts hurt.
         List<StudyGoal> goals = studyService.getStudyGoals().stream()
             .filter(g -> g.getDate().isAfter(dateTimeService.getCurrentDate().minusDays(30)))
             .collect(Collectors.toList());
         double goalScore = 0;
         if (!goals.isEmpty()) {
             long achievedGoals = goals.stream().filter(StudyGoal::isAchieved).count();
-            goalScore = ((double) achievedGoals / goals.size()) * 10;
+            long missedGoals = goals.stream().filter(StudyGoal::isFailed).count();
+            double normalized = ((double) (achievedGoals - missedGoals + goals.size())) / (2.0 * goals.size());
+            goalScore = Math.max(0, Math.min(1, normalized)) * 10;
         }
         
         return focusScore + consistencyScore + volumeScore + goalScore;

--- a/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
@@ -451,7 +451,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
             .collect(Collectors.toList());
         
         if (recentGoals.isEmpty()) {
-            Label noGoalsLabel = new Label("No goal attempts recorded yet.");
+            Label noGoalsLabel = new Label("No goals recorded yet.");
             TaskStyleUtils.fontNormal(noGoalsLabel, 12);
             noGoalsLabel.setTextFill(Color.web("#7f8c8d"));
             noGoalsLabel.setPadding(new Insets(10, 0, 0, 0));
@@ -533,7 +533,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         List<StudyGoal> allGoals = studyService.getStudyGoals();
         
         if (allGoals.isEmpty()) {
-            Label noGoalsLabel = new Label("No goal attempts recorded yet.");
+            Label noGoalsLabel = new Label("No goals recorded yet.");
             TaskStyleUtils.fontNormal(noGoalsLabel, 14);
             noGoalsLabel.setTextFill(Color.web("#7f8c8d"));
             noGoalsLabel.setWrapText(true);
@@ -782,7 +782,7 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
             HBox row2 = new HBox(15);
             row2.setAlignment(Pos.CENTER);
             
-            VBox goalsCard = createStatCard("Goal Score", String.format("%+d", goalAttemptScore), "Achieved minus missed attempts", "#27ae60");
+            VBox goalsCard = createStatCard("Lifetime net", String.format("%+d", goalAttemptScore), "Achieved minus missed goals", "#27ae60");
             VBox tasksCard = createStatCard("Tasks Done", String.valueOf(completedTasks), "Completed tasks", "#16a085");
             VBox efficiencyCard = createStatCard("Efficiency", 
                 totalMinutes > 0 ? String.format("%.1f", (double) totalPoints / totalMinutes * 60) : "0", 

--- a/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ProfileViewPanel.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -97,13 +98,14 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         // Statistics cards
         HBox statsSection = createStatsSection();
         
-        // Achieved goals section
-        VBox achievedGoalsSection = createAchievedGoalsSection();
+        // Goal history section
+        VBox goalHistorySection = createGoalHistorySection();
         
         // Charts section
         VBox chartsSection = createChartsSection();
         
-        mainContent.getChildren().addAll(headerLabel, driveSyncSection, profileSection, statsSection, achievedGoalsSection, chartsSection);
+        mainContent.getChildren().addAll(headerLabel, driveSyncSection, profileSection, statsSection,
+                goalHistorySection, chartsSection);
     }
     
     private VBox createDriveSyncSection() {
@@ -410,61 +412,64 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         return section;
     }
     
-    private VBox createAchievedGoalsSection() {
+    private VBox createGoalHistorySection() {
         VBox section = new VBox(15);
         section.getStyleClass().add("section-card");
         
         HBox header = new HBox(15);
         header.setAlignment(Pos.CENTER_LEFT);
         
-        Label sectionTitle = new Label("Achieved Goals");
+        Label sectionTitle = new Label("Goal History");
         sectionTitle.setGraphic(TaskStyleUtils.iconLabel("\u2666", 18));
         TaskStyleUtils.fontBold(sectionTitle, 18);
         
-        // Get recent achieved goals count
-        List<StudyGoal> allAchievedGoals = studyService.getStudyGoals().stream()
-            .filter(StudyGoal::isAchieved)
-            .collect(Collectors.toList());
+        List<StudyGoal> allGoals = getSortedGoalHistory("Newest first");
+        long achievedCount = allGoals.stream().filter(StudyGoal::isAchieved).count();
+        long failedCount = allGoals.stream().filter(StudyGoal::isFailed).count();
+        long activeCount = allGoals.stream()
+            .filter(goal -> !goal.isAchieved() && !goal.isFailed())
+            .count();
         
-        Label countLabel = new Label("(" + allAchievedGoals.size() + " total)");
+        Label countLabel = new Label("(" + achievedCount + " achieved, "
+                + failedCount + " missed/failed, " + activeCount + " active)");
         TaskStyleUtils.fontNormal(countLabel, 14);
         countLabel.setTextFill(Color.web("#7f8c8d"));
         
-        Button viewAllBtn = new Button("» View All Achieved Goals");
+        Button viewAllBtn = new Button("» View All Goals");
         viewAllBtn.getStyleClass().add("btn-success");
-        viewAllBtn.setOnAction(e -> showAllAchievedGoalsDialog());
+        viewAllBtn.setOnAction(e -> showAllGoalsDialog());
         
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
         
         header.getChildren().addAll(sectionTitle, countLabel, spacer, viewAllBtn);
         
-        // Show recent achieved goals (last 5)
+        // Show recent goal activity (last 5 attempts, newest first)
         VBox recentGoalsContainer = new VBox(8);
-        List<StudyGoal> recentAchievedGoals = allAchievedGoals.stream()
-            .sorted((g1, g2) -> g2.getDate().compareTo(g1.getDate())) // Sort by date descending
+        List<StudyGoal> recentGoals = allGoals.stream()
             .limit(5)
             .collect(Collectors.toList());
         
-        if (recentAchievedGoals.isEmpty()) {
-            Label noGoalsLabel = new Label("No goals achieved yet. Start setting and completing goals to see them here!");
+        if (recentGoals.isEmpty()) {
+            Label noGoalsLabel = new Label("No goal attempts recorded yet.");
             TaskStyleUtils.fontNormal(noGoalsLabel, 12);
             noGoalsLabel.setTextFill(Color.web("#7f8c8d"));
             noGoalsLabel.setPadding(new Insets(10, 0, 0, 0));
             recentGoalsContainer.getChildren().add(noGoalsLabel);
         } else {
-            Label recentLabel = new Label("Recent Achievements:");
+            Label recentLabel = new Label("Recent Goal Activity:");
             TaskStyleUtils.fontSemiBold(recentLabel, 12);
             recentLabel.setTextFill(Color.web("#2c3e50"));
             recentGoalsContainer.getChildren().add(recentLabel);
             
-            for (StudyGoal goal : recentAchievedGoals) {
-                HBox goalItem = createAchievedGoalItem(goal);
+            for (StudyGoal goal : recentGoals) {
+                HBox goalItem = createGoalHistoryItem(goal, false);
                 recentGoalsContainer.getChildren().add(goalItem);
             }
             
-            if (allAchievedGoals.size() > 5) {
-                Label moreLabel = new Label("... and " + (allAchievedGoals.size() - 5) + " more. Click 'View All' to see them.");
+            if (allGoals.size() > 5) {
+                Label moreLabel = new Label("... and " + (allGoals.size() - 5)
+                        + " more. Click 'View All Goals' to filter and sort them.");
                 TaskStyleUtils.fontItalic(moreLabel, 11);
                 moreLabel.setTextFill(Color.web("#95a5a6"));
                 recentGoalsContainer.getChildren().add(moreLabel);
@@ -475,50 +480,60 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
         return section;
     }
     
-    private HBox createAchievedGoalItem(StudyGoal goal) {
+    private HBox createGoalHistoryItem(StudyGoal goal, boolean detailed) {
         HBox item = new HBox(10);
         item.setAlignment(Pos.CENTER_LEFT);
-        item.setPadding(new Insets(8, 12, 8, 12));
-        item.setStyle("-fx-background-color: #e8f5e8; -fx-background-radius: 5; -fx-border-color: #27ae60; -fx-border-radius: 5;");
-        
-        Label checkLabel = new Label("\u2713");
-        TaskStyleUtils.fontEmoji(checkLabel, 14);
-        
-        VBox textContainer = new VBox(2);
+        item.setPadding(detailed ? new Insets(10, 15, 10, 15) : new Insets(8, 12, 8, 12));
+        item.setStyle("-fx-background-color: " + goalHistoryBackground(goal)
+                + "; -fx-background-radius: " + (detailed ? "8" : "5")
+                + "; -fx-border-color: " + goalHistoryColor(goal)
+                + "; -fx-border-radius: " + (detailed ? "8" : "5")
+                + "; -fx-border-width: 1;");
+
+        Label statusIcon = new Label(goalHistoryIcon(goal));
+        TaskStyleUtils.fontEmoji(statusIcon, detailed ? 16 : 14);
+        statusIcon.setTextFill(Color.web(goalHistoryColor(goal)));
+
+        VBox textContainer = new VBox(detailed ? 4 : 2);
+        HBox.setHgrow(textContainer, Priority.ALWAYS);
         
         Label descLabel = new Label(goal.getDescription());
-        TaskStyleUtils.fontNormal(descLabel, 12);
+        TaskStyleUtils.fontNormal(descLabel, detailed ? 13 : 12);
         descLabel.setWrapText(true);
         
-        Label dateLabel = new Label("Achieved on " + goal.getDate().format(DateTimeFormatter.ofPattern("MMM dd, yyyy")));
-        TaskStyleUtils.fontNormal(dateLabel, 10);
+        HBox detailsBox = new HBox(15);
+        detailsBox.setAlignment(Pos.CENTER_LEFT);
+
+        Label dateLabel = new Label(goalHistoryDateText(goal, detailed));
+        TaskStyleUtils.fontNormal(dateLabel, detailed ? 11 : 10);
         dateLabel.setTextFill(Color.web("#7f8c8d"));
+
+        Label attemptLabel = new Label("Attempt " + goal.getAttemptNumber());
+        TaskStyleUtils.fontNormal(attemptLabel, detailed ? 11 : 10);
+        attemptLabel.setTextFill(Color.web(goalHistoryColor(goal)));
         
-        textContainer.getChildren().addAll(descLabel, dateLabel);
+        detailsBox.getChildren().addAll(dateLabel, attemptLabel);
+        textContainer.getChildren().addAll(descLabel, detailsBox);
         
-        item.getChildren().addAll(checkLabel, textContainer);
+        item.getChildren().addAll(statusIcon, textContainer);
         return item;
     }
     
-    private void showAllAchievedGoalsDialog() {
+    private void showAllGoalsDialog() {
         Dialog<Void> dialog = new Dialog<>();
         dialog.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
-        dialog.setTitle("All Achieved Goals");
-        dialog.setHeaderText("\u2666 Your Achievement History");
+        dialog.setTitle("All Goals");
+        dialog.setHeaderText("\u2666 Goal History");
         
-        VBox content = new VBox(10);
+        VBox content = new VBox(12);
         content.setPadding(new Insets(20));
-        content.setPrefWidth(600);
-        content.setPrefHeight(500);
+        content.setPrefWidth(720);
+        content.setPrefHeight(560);
         
-        // Get all achieved goals sorted by date (most recent first)
-        List<StudyGoal> allAchievedGoals = studyService.getStudyGoals().stream()
-            .filter(StudyGoal::isAchieved)
-            .sorted((g1, g2) -> g2.getDate().compareTo(g1.getDate()))
-            .collect(Collectors.toList());
+        List<StudyGoal> allGoals = studyService.getStudyGoals();
         
-        if (allAchievedGoals.isEmpty()) {
-            Label noGoalsLabel = new Label("You haven't achieved any goals yet.\n\nStart by setting daily study goals and completing them to build your achievement history!");
+        if (allGoals.isEmpty()) {
+            Label noGoalsLabel = new Label("No goal attempts recorded yet.");
             TaskStyleUtils.fontNormal(noGoalsLabel, 14);
             noGoalsLabel.setTextFill(Color.web("#7f8c8d"));
             noGoalsLabel.setWrapText(true);
@@ -526,92 +541,172 @@ public class ProfileViewPanel extends ScrollPane implements RefreshablePanel {
             noGoalsLabel.setPadding(new Insets(50, 20, 50, 20));
             content.getChildren().add(noGoalsLabel);
         } else {
-            Label totalLabel = new Label("Total Achieved Goals: " + allAchievedGoals.size());
+            HBox controls = new HBox(10);
+            controls.setAlignment(Pos.CENTER_LEFT);
+
+            ComboBox<String> filterCombo = new ComboBox<>();
+            filterCombo.getItems().addAll("All goals", "Achieved", "Missed / failed", "Active / pending");
+            filterCombo.setValue("All goals");
+
+            ComboBox<String> sortCombo = new ComboBox<>();
+            sortCombo.getItems().addAll("Newest first", "Oldest first", "Status", "Attempt number", "Description");
+            sortCombo.setValue("Newest first");
+
+            Label totalLabel = new Label();
             TaskStyleUtils.fontBold(totalLabel, 14);
-            totalLabel.setTextFill(Color.web("#27ae60"));
-            content.getChildren().add(totalLabel);
+            totalLabel.setTextFill(Color.web("#2c3e50"));
+
+            controls.getChildren().addAll(new Label("Show:"), filterCombo, new Label("Sort:"), sortCombo, totalLabel);
             
             ScrollPane scrollPane = new ScrollPane();
             VBox goalsContainer = new VBox(8);
             goalsContainer.setPadding(new Insets(10));
-            
-            // Group goals by month for better organization
-            Map<String, List<StudyGoal>> goalsByMonth = allAchievedGoals.stream()
-                .collect(Collectors.groupingBy(goal -> 
-                    goal.getDate().format(DateTimeFormatter.ofPattern("MMMM yyyy"))));
-            
-            for (Map.Entry<String, List<StudyGoal>> monthEntry : goalsByMonth.entrySet()) {
-                // Month header
-                Label monthLabel = new Label("» " + monthEntry.getKey());
-                TaskStyleUtils.fontBold(monthLabel, 16);
-                monthLabel.setPadding(new Insets(15, 0, 5, 0));
-                goalsContainer.getChildren().add(monthLabel);
-                
-                // Goals for this month
-                for (StudyGoal goal : monthEntry.getValue()) {
-                    HBox goalItem = createDetailedAchievedGoalItem(goal);
-                    goalsContainer.getChildren().add(goalItem);
-                }
-            }
-            
+
             scrollPane.setContent(goalsContainer);
             scrollPane.setFitToWidth(true);
-            scrollPane.setPrefHeight(400);
-            content.getChildren().add(scrollPane);
+            scrollPane.setPrefHeight(430);
+
+            Runnable refresh = () -> populateGoalHistoryDialog(
+                    goalsContainer, totalLabel, allGoals, filterCombo.getValue(), sortCombo.getValue());
+            filterCombo.setOnAction(e -> refresh.run());
+            sortCombo.setOnAction(e -> refresh.run());
+            refresh.run();
+
+            content.getChildren().addAll(controls, scrollPane);
         }
         
         dialog.getDialogPane().setContent(content);
         dialog.getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
-        dialog.getDialogPane().setMinSize(620, 540);
+        dialog.getDialogPane().setMinSize(740, 600);
         dialog.setResizable(true);
 
         dialog.setOnShown(e -> {
-            dialog.setWidth(640);
-            dialog.setHeight(560);
+            dialog.setWidth(760);
+            dialog.setHeight(620);
         });
 
         dialog.showAndWait();
     }
-    
-    private HBox createDetailedAchievedGoalItem(StudyGoal goal) {
-        HBox item = new HBox(12);
-        item.setAlignment(Pos.CENTER_LEFT);
-        item.setPadding(new Insets(10, 15, 10, 15));
-        item.setStyle("-fx-background-color: #f8f9fa; -fx-background-radius: 8; -fx-border-color: #27ae60; -fx-border-radius: 8; -fx-border-width: 1;");
-        
-        Label checkLabel = new Label("\u2713");
-        TaskStyleUtils.fontEmoji(checkLabel, 16);
-        
-        VBox textContainer = new VBox(4);
-        HBox.setHgrow(textContainer, Priority.ALWAYS);
-        
-        Label descLabel = new Label(goal.getDescription());
-        TaskStyleUtils.fontNormal(descLabel, 13);
-        descLabel.setWrapText(true);
-        
-        HBox detailsBox = new HBox(15);
-        detailsBox.setAlignment(Pos.CENTER_LEFT);
-        
-        Label dateLabel = new Label("» " + goal.getDate().format(DateTimeFormatter.ofPattern("EEE, MMM dd, yyyy")));
-        TaskStyleUtils.fontNormal(dateLabel, 11);
-        dateLabel.setTextFill(Color.web("#7f8c8d"));
-        
-        // Show attempt history if achievement followed one or more misses.
-        if (goal.isDelayed()) {
-            Label delayLabel = new Label("[!]  Attempt " + goal.getAttemptNumber()
-                    + " after " + goal.getMissedAttemptCount() + " miss"
-                    + (goal.getMissedAttemptCount() == 1 ? "" : "es"));
-            TaskStyleUtils.fontNormal(delayLabel, 11);
-            delayLabel.setTextFill(Color.web("#e67e22"));
-            detailsBox.getChildren().addAll(dateLabel, delayLabel);
-        } else {
-            detailsBox.getChildren().add(dateLabel);
+
+    private void populateGoalHistoryDialog(VBox goalsContainer, Label totalLabel,
+                                           List<StudyGoal> allGoals, String filter, String sort) {
+        goalsContainer.getChildren().clear();
+        List<StudyGoal> visibleGoals = allGoals.stream()
+            .filter(goal -> matchesGoalHistoryFilter(goal, filter))
+            .sorted(goalHistoryComparator(sort))
+            .collect(Collectors.toList());
+
+        totalLabel.setText("(" + visibleGoals.size() + " shown)");
+
+        if (visibleGoals.isEmpty()) {
+            Label emptyLabel = new Label("No goals match this filter.");
+            TaskStyleUtils.fontNormal(emptyLabel, 13);
+            emptyLabel.setTextFill(Color.web("#7f8c8d"));
+            emptyLabel.setPadding(new Insets(30));
+            goalsContainer.getChildren().add(emptyLabel);
+            return;
         }
-        
-        textContainer.getChildren().addAll(descLabel, detailsBox);
-        
-        item.getChildren().addAll(checkLabel, textContainer);
-        return item;
+
+        for (StudyGoal goal : visibleGoals) {
+            goalsContainer.getChildren().add(createGoalHistoryItem(goal, true));
+        }
+    }
+
+    private List<StudyGoal> getSortedGoalHistory(String sort) {
+        return studyService.getStudyGoals().stream()
+            .sorted(goalHistoryComparator(sort))
+            .collect(Collectors.toList());
+    }
+
+    private boolean matchesGoalHistoryFilter(StudyGoal goal, String filter) {
+        return switch (filter) {
+            case "Achieved" -> goal.isAchieved();
+            case "Missed / failed" -> goal.isFailed();
+            case "Active / pending" -> !goal.isAchieved() && !goal.isFailed();
+            default -> true;
+        };
+    }
+
+    private Comparator<StudyGoal> goalHistoryComparator(String sort) {
+        return switch (sort) {
+            case "Oldest first" -> Comparator
+                .comparing(StudyGoal::getDate)
+                .thenComparingInt(StudyGoal::getAttemptNumber)
+                .thenComparing(goal -> safeText(goal.getDescription()), String.CASE_INSENSITIVE_ORDER);
+            case "Attempt number" -> Comparator
+                .comparingInt(StudyGoal::getAttemptNumber).reversed()
+                .thenComparing(StudyGoal::getDate, Comparator.reverseOrder())
+                .thenComparing(goal -> safeText(goal.getDescription()), String.CASE_INSENSITIVE_ORDER);
+            case "Status" -> Comparator
+                .comparingInt(this::goalHistoryStatusRank)
+                .thenComparing(StudyGoal::getDate, Comparator.reverseOrder())
+                .thenComparing(Comparator.comparingInt(StudyGoal::getAttemptNumber).reversed())
+                .thenComparing(goal -> safeText(goal.getDescription()), String.CASE_INSENSITIVE_ORDER);
+            case "Description" -> Comparator
+                .comparing((StudyGoal goal) -> safeText(goal.getDescription()), String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(StudyGoal::getDate, Comparator.reverseOrder())
+                .thenComparing(Comparator.comparingInt(StudyGoal::getAttemptNumber).reversed());
+            default -> Comparator
+                .comparing(StudyGoal::getDate, Comparator.reverseOrder())
+                .thenComparing(Comparator.comparingInt(StudyGoal::getAttemptNumber).reversed())
+                .thenComparing(goal -> safeText(goal.getDescription()), String.CASE_INSENSITIVE_ORDER);
+        };
+    }
+
+    private int goalHistoryStatusRank(StudyGoal goal) {
+        if (goal.isFailed()) {
+            return 0;
+        }
+        if (goal.isAchieved()) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private String goalHistoryIcon(StudyGoal goal) {
+        if (goal.isAchieved()) {
+            return "\u2713";
+        }
+        if (goal.isFailed()) {
+            return "\u2715";
+        }
+        return "\u25CB";
+    }
+
+    private String goalHistoryColor(StudyGoal goal) {
+        if (goal.isAchieved()) {
+            return "#27ae60";
+        }
+        if (goal.isFailed()) {
+            return "#c0392b";
+        }
+        return "#3498db";
+    }
+
+    private String goalHistoryBackground(StudyGoal goal) {
+        if (goal.isAchieved()) {
+            return "#e8f5e8";
+        }
+        if (goal.isFailed()) {
+            return "#fdecea";
+        }
+        return "#e3f2fd";
+    }
+
+    private String goalHistoryDateText(StudyGoal goal, boolean detailed) {
+        String date = goal.getDate().format(DateTimeFormatter.ofPattern(
+                detailed ? "EEE, MMM dd, yyyy" : "MMM dd, yyyy"));
+        if (goal.isAchieved()) {
+            return "Achieved on " + date;
+        }
+        if (goal.isFailed()) {
+            return (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned on " : "Missed on ") + date;
+        }
+        return "Planned for " + date;
+    }
+
+    private String safeText(String text) {
+        return text == null ? "" : text;
     }
     
     private VBox createChartsSection() {

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -199,14 +199,14 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox sectionHeader = new HBox(15);
         sectionHeader.setAlignment(Pos.CENTER_LEFT);
 
-        taskSectionTitle = new Label("Today's Tasks & Goal Attempts");
+        taskSectionTitle = new Label("Today's Tasks & Goals");
         taskSectionTitle.setGraphic(TaskStyleUtils.iconLabel("\u2611", 18));
         TaskStyleUtils.fontBold(taskSectionTitle, 18);
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
-        Button addGoalBtn = new Button("+ Add Goal Attempt");
+        Button addGoalBtn = new Button("+ Add Goal");
         addGoalBtn.getStyleClass().add("btn-purple");
         addGoalBtn.setOnAction(e -> showAddGoalDialog(null));
 
@@ -228,8 +228,8 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         allTasksViewBtn.setToggleGroup(viewGroup);
         todayViewBtn.setSelected(currentTaskView == PlannerTaskView.TODAY);
         allTasksViewBtn.setSelected(currentTaskView == PlannerTaskView.ALL_TASKS);
-        todayViewBtn.getStyleClass().addAll("btn-gray", "btn-small");
-        allTasksViewBtn.getStyleClass().addAll("btn-gray", "btn-small");
+        todayViewBtn.getStyleClass().addAll("planner-view-toggle", "btn-small");
+        allTasksViewBtn.getStyleClass().addAll("planner-view-toggle", "btn-small");
         todayViewBtn.setOnAction(e -> {
             if (!todayViewBtn.isSelected()) {
                 todayViewBtn.setSelected(true);
@@ -258,7 +258,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         Label groupLabel = new Label("Group:");
         TaskStyleUtils.fontBold(groupLabel, 12);
         ComboBox<String> groupCombo = new ComboBox<>();
-        groupCombo.getItems().addAll("None", "Status", "Category", "Reason");
+        groupCombo.getItems().addAll("None", "Status", "Category", "Deadline");
         groupCombo.setValue(currentGroup);
         groupCombo.setOnAction(e -> {
             currentGroup = groupCombo.getValue();
@@ -363,8 +363,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         tasksContainer.getChildren().clear();
 
         if (taskSectionTitle != null) {
-            taskSectionTitle.setText(currentTaskView == PlannerTaskView.TODAY
-                    ? "Today's Tasks & Goal Attempts" : "All Active Tasks");
+            taskSectionTitle.setText(taskSectionTitleText());
         }
 
         refreshDisplayDateAttemptCache();
@@ -454,6 +453,11 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             }
         }
 
+        VBox unlinkedRetrySection = buildUnlinkedRetrySection();
+        if (unlinkedRetrySection != null) {
+            tasksContainer.getChildren().add(unlinkedRetrySection);
+        }
+
         // Unlinked attempts section (goals with no task)
         if (dateScopedView) {
             List<StudyGoal> allUnlinked = StudyGoal.findUnlinkedForDate(displayDate);
@@ -464,7 +468,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             if (!unlinkedGoals.isEmpty() || !completedUnlinked.isEmpty()) {
                 VBox unlinkedSection = new VBox(6);
                 unlinkedSection.setPadding(new Insets(10, 0, 0, 0));
-                Label unlinkedTitle = new Label("Goal attempts without a task:");
+                Label unlinkedTitle = new Label("Goals without a task:");
                 TaskStyleUtils.fontBold(unlinkedTitle, 13);
                 unlinkedTitle.setTextFill(Color.web("#6c757d"));
                 unlinkedSection.getChildren().add(unlinkedTitle);
@@ -501,25 +505,32 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         int score = (int) (achieved - missed);
 
         attemptOverviewContainer.getChildren().addAll(
-                createAttemptMetricCard("Attempts Today", String.valueOf(attempts.size()), "#3949ab", "#e8eaf6"),
-                createAttemptMetricCard("Pending", String.valueOf(pending), "#0d47a1", "#e3f2fd"),
-                createAttemptMetricCard("Retries", String.valueOf(retrying), "#e65100", "#fff3e0"),
-                createAttemptMetricCard("Achieved", String.valueOf(achieved), "#1b5e20", "#e8f5e9"),
-                createAttemptMetricCard("Missed", String.valueOf(missed), "#b71c1c", "#ffebee"),
-                createAttemptMetricCard("Score", String.format("%+d", score), "#4a148c", "#f3e5f5")
+                createAttemptMetricCard("Today's net", String.format("%+d", score),
+                        TaskStyleUtils.COLOR_PURPLE, TaskStyleUtils.TINT_PURPLE, true),
+                createAttemptMetricCard("Goals", String.valueOf(attempts.size()),
+                        TaskStyleUtils.COLOR_PRIMARY, TaskStyleUtils.TINT_NEUTRAL, false),
+                createAttemptMetricCard("Pending", String.valueOf(pending),
+                        TaskStyleUtils.COLOR_PRIMARY, TaskStyleUtils.TINT_NEUTRAL, false),
+                createAttemptMetricCard("Retry", String.valueOf(retrying),
+                        TaskStyleUtils.COLOR_ORANGE, TaskStyleUtils.TINT_NEUTRAL, false),
+                createAttemptMetricCard("Done", String.valueOf(achieved),
+                        TaskStyleUtils.COLOR_SUCCESS, TaskStyleUtils.TINT_NEUTRAL, false),
+                createAttemptMetricCard("Missed", String.valueOf(missed),
+                        TaskStyleUtils.COLOR_DANGER, TaskStyleUtils.TINT_NEUTRAL, false)
         );
     }
 
-    private VBox createAttemptMetricCard(String title, String value, String textColor, String backgroundColor) {
+    private VBox createAttemptMetricCard(String title, String value, String textColor,
+                                         String backgroundColor, boolean primary) {
         VBox card = new VBox(2);
         card.setAlignment(Pos.CENTER_LEFT);
-        card.setMinWidth(105);
-        card.setPadding(new Insets(8, 10, 8, 10));
+        card.setMinWidth(primary ? 120 : 78);
+        card.setPadding(primary ? new Insets(8, 12, 8, 12) : new Insets(6, 9, 6, 9));
         card.setStyle("-fx-background-color: " + backgroundColor + "; -fx-background-radius: 8;"
                 + " -fx-border-color: #d6dbe0; -fx-border-radius: 8;");
 
         Label valueLabel = new Label(value);
-        TaskStyleUtils.fontBold(valueLabel, 18);
+        TaskStyleUtils.fontBold(valueLabel, primary ? 18 : 14);
         valueLabel.setTextFill(Color.web(textColor));
 
         Label titleLabel = new Label(title);
@@ -528,6 +539,17 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         card.getChildren().addAll(valueLabel, titleLabel);
         return card;
+    }
+
+    private String taskSectionTitleText() {
+        if (currentTaskView == PlannerTaskView.ALL_TASKS) {
+            return "All Active Tasks";
+        }
+        LocalDate today = dateTimeService.getCurrentDate();
+        if (displayDate.equals(today)) {
+            return "Today's Tasks & Goals";
+        }
+        return "Tasks & Goals - " + displayDate.format(DateTimeFormatter.ofPattern("MMM d"));
     }
 
     private List<StudyGoal> getAllAttemptsForDisplayDate() {
@@ -636,24 +658,24 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             case "Status" -> task.getStatus().name();
             case "Category" -> task.getCategory() != null && !task.getCategory().isBlank()
                     ? task.getCategory() : "Uncategorized";
-            case "Reason" -> reasonGroupKeyFor(task);
+            case "Deadline", "Reason" -> reasonGroupKeyFor(task);
             default -> "";
         };
     }
 
     private String reasonGroupKeyFor(Task task) {
         if (task.isRecurring() && surfacesByDateRules(task, displayDate)) {
-            return "Recurring today";
+            return "Recurring";
         }
         LocalDate deadline = task.getDeadline();
         if (deadline != null && deadline.equals(displayDate) && surfacesByDateRules(task, displayDate)) {
-            return "Due today";
+            return "Due";
         }
         if (deadline != null && deadline.isBefore(displayDate) && surfacesByDateRules(task, displayDate)) {
             return "Overdue";
         }
         if (hasGoalOnDisplayDate(task)) {
-            return "Has goal today";
+            return "Has goal";
         }
         if (currentTaskView == PlannerTaskView.TODAY
                 && !task.isRecurring()
@@ -687,6 +709,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         Label taskTitle = new Label(task.getTitle());
         TaskStyleUtils.fontBold(taskTitle, 14);
+        taskTitle.setWrapText(true);
+        taskTitle.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(taskTitle, Priority.ALWAYS);
 
         Label priorityLabel = new Label(task.getPriority() != null ? task.getPriority().toString() : "");
         priorityLabel.setTextFill(Color.web("#f39c12"));
@@ -698,18 +723,16 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         TaskStyleUtils.fontBold(statusBadge, 10);
         statusBadge.setTextFill(TaskStyleUtils.statusTextColor(task.getStatus()));
 
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        headerRow.getChildren().add(arrow);
         if (task.isRecurring()) {
             Label recurBadge = TaskStyleUtils.iconLabel("\u21BA", 12);
             recurBadge.setTooltip(new Tooltip(task.getRecurringSummary()));
             headerRow.getChildren().add(recurBadge);
         }
-
-        Region spacer = new Region();
-        HBox.setHgrow(spacer, Priority.ALWAYS);
-
-        headerRow.getChildren().addAll(0, List.of(arrow)); // arrow first
         headerRow.getChildren().addAll(taskTitle, priorityLabel);
-        headerRow.getChildren().addAll(createTaskAttemptBadges(task));
         headerRow.getChildren().add(spacer);
 
         // Overdue / due-today badge (between spacer and status badge)
@@ -720,6 +743,14 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         }
 
         headerRow.getChildren().add(statusBadge);
+
+        List<Label> attemptBadges = createTaskAttemptBadges(task);
+        FlowPane badgeRow = new FlowPane(6, 4);
+        badgeRow.setPadding(new Insets(0, 14, 10, 42));
+        badgeRow.getChildren().addAll(attemptBadges);
+        badgeRow.setVisible(!attemptBadges.isEmpty());
+        badgeRow.setManaged(!attemptBadges.isEmpty());
+        badgeRow.setStyle("-fx-cursor: hand;");
 
         // ── Expandable goals panel ──
         VBox goalsPanel = new VBox(6);
@@ -735,7 +766,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         }
 
         // Toggle expand/collapse on header click
-        headerRow.setOnMouseClicked(e -> {
+        Runnable toggleExpanded = () -> {
             boolean nowVisible = !goalsPanel.isVisible();
             goalsPanel.setVisible(nowVisible);
             goalsPanel.setManaged(nowVisible);
@@ -746,9 +777,11 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             } else {
                 expandedTaskIds.remove(task.getId());
             }
-        });
+        };
+        headerRow.setOnMouseClicked(e -> toggleExpanded.run());
+        badgeRow.setOnMouseClicked(e -> toggleExpanded.run());
 
-        card.getChildren().addAll(headerRow, goalsPanel);
+        card.getChildren().addAll(headerRow, badgeRow, goalsPanel);
         return card;
     }
 
@@ -768,30 +801,25 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         long retries = attempts.stream().filter(goal -> goal.getMissedAttemptCount() > 0).count();
 
         List<Label> badges = new ArrayList<>();
-        badges.add(createTaskAttemptBadge(attempts.size() + " attempt" + (attempts.size() == 1 ? "" : "s"),
-                "#3949ab", "#e8eaf6"));
+        badges.add(createTaskAttemptBadge(attempts.size() + " goal" + (attempts.size() == 1 ? "" : "s"),
+                TaskStyleUtils.COLOR_PRIMARY, TaskStyleUtils.TINT_NEUTRAL));
         if (pending > 0) {
-            badges.add(createTaskAttemptBadge(pending + " pending", "#0d47a1", "#e3f2fd"));
+            badges.add(createTaskAttemptBadge(pending + " pending", TaskStyleUtils.COLOR_PRIMARY, TaskStyleUtils.TINT_PRIMARY));
         }
         if (retries > 0) {
-            badges.add(createTaskAttemptBadge(retries + " retry", "#e65100", "#fff3e0"));
+            badges.add(createTaskAttemptBadge(retries + " retry", TaskStyleUtils.retryTextColor(), TaskStyleUtils.retryBackgroundColor()));
         }
         if (achieved > 0) {
-            badges.add(createTaskAttemptBadge(achieved + " done", "#1b5e20", "#e8f5e9"));
+            badges.add(createTaskAttemptBadge(achieved + " done", TaskStyleUtils.COLOR_SUCCESS, TaskStyleUtils.TINT_SUCCESS));
         }
         if (missed > 0) {
-            badges.add(createTaskAttemptBadge(missed + " missed", "#b71c1c", "#ffebee"));
+            badges.add(createTaskAttemptBadge(missed + " missed", TaskStyleUtils.COLOR_DANGER, TaskStyleUtils.TINT_DANGER));
         }
         return badges;
     }
 
     private Label createTaskAttemptBadge(String text, String textColor, String backgroundColor) {
-        Label badge = new Label(text);
-        TaskStyleUtils.fontBold(badge, 10);
-        badge.setTextFill(Color.web(textColor));
-        badge.setPadding(new Insets(2, 7, 2, 7));
-        badge.setStyle("-fx-background-color: " + backgroundColor + "; -fx-background-radius: 10;");
-        return badge;
+        return TaskStyleUtils.createAttemptBadge(text, textColor, backgroundColor);
     }
 
     /**
@@ -852,11 +880,11 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             if (retrySection != null) {
                 goalsPanel.getChildren().add(retrySection);
             } else {
-                Label noGoals = new Label("No goal attempts linked to this task for this date.");
+                Label noGoals = new Label("No goals linked to this task for this date.");
                 TaskStyleUtils.fontNormal(noGoals, 12);
                 noGoals.setTextFill(Color.web("#7f8c8d"));
 
-                Button addGoalBtn = new Button("+ Create Goal Attempt");
+                Button addGoalBtn = new Button("+ Create Goal");
                 addGoalBtn.getStyleClass().addAll("btn-purple", "btn-small");
                 addGoalBtn.setOnAction(e -> {
                     showAddGoalDialog(task);
@@ -869,7 +897,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             for (StudyGoal goal : activeGoals) {
                 goalsPanel.getChildren().add(buildGoalRow(goal, task));
             }
-            Button addMoreBtn = new Button("+ Add Goal Attempt");
+            Button addMoreBtn = new Button("+ Add Goal");
             addMoreBtn.getStyleClass().addAll("btn-purple", "btn-small");
             addMoreBtn.setOnAction(e -> {
                 showAddGoalDialog(task);
@@ -878,7 +906,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             goalsPanel.getChildren().add(addMoreBtn);
         }
 
-        // Completed attempts - collapsible section
+        // Completed goals - collapsible section
         if (!completedGoals.isEmpty()) {
             goalsPanel.getChildren().add(
                     buildCompletedGoalsSection(completedGoals));
@@ -887,6 +915,31 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         if (retrySection != null && (!activeGoals.isEmpty() || !completedGoals.isEmpty())) {
             goalsPanel.getChildren().add(retrySection);
         }
+    }
+
+    private VBox buildUnlinkedRetrySection() {
+        if (currentTaskView != PlannerTaskView.TODAY
+                || !displayDate.equals(dateTimeService.getCurrentDate())) {
+            return null;
+        }
+        List<StudyGoal> retryableGoals = studyService.getUnlinkedDelayedGoalsForReplanning();
+        if (retryableGoals.isEmpty()) {
+            return null;
+        }
+
+        VBox section = new VBox(6);
+        section.setPadding(new Insets(10, 0, 0, 0));
+
+        Label header = new Label("Missed goals without a task");
+        header.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 12));
+        TaskStyleUtils.fontBold(header, 13);
+        header.setTextFill(Color.web(TaskStyleUtils.retryTextColor()));
+        section.getChildren().add(header);
+
+        for (StudyGoal goal : retryableGoals) {
+            section.getChildren().add(buildTaskRetryRow(goal));
+        }
+        return section;
     }
 
     private VBox buildTaskRetrySection(Task task) {
@@ -901,10 +954,10 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         VBox section = new VBox(6);
         section.setPadding(new Insets(8, 0, 0, 0));
 
-        Label header = new Label("Missed attempts ready to retry");
+        Label header = new Label("Missed goals ready to retry");
         header.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 12));
         TaskStyleUtils.fontBold(header, 12);
-        header.setTextFill(Color.web("#d35400"));
+        header.setTextFill(Color.web(TaskStyleUtils.retryTextColor()));
         section.getChildren().add(header);
 
         for (StudyGoal goal : retryableGoals) {
@@ -917,14 +970,14 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox row = new HBox(10);
         row.setAlignment(Pos.CENTER_LEFT);
         row.setPadding(new Insets(6, 8, 6, 8));
-        row.setStyle("-fx-background-color: #fff3e0; -fx-background-radius: 5;");
+        row.setStyle("-fx-background-color: " + TaskStyleUtils.retryBackgroundColor() + "; -fx-background-radius: 5;");
 
         VBox textBox = new VBox(2);
         Label goalLabel = new Label(goal.getDescription());
         TaskStyleUtils.fontNormal(goalLabel, 13);
         Label attemptLabel = new Label(formatRetryAttemptSummary(goal));
         TaskStyleUtils.fontNormal(attemptLabel, 11);
-        attemptLabel.setTextFill(Color.web("#d35400"));
+        attemptLabel.setTextFill(Color.web(TaskStyleUtils.retryTextColor()));
         textBox.getChildren().addAll(goalLabel, attemptLabel);
 
         Region spacer = new Region();
@@ -957,7 +1010,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         row.setAlignment(Pos.CENTER_LEFT);
         row.setPadding(new Insets(6, 8, 6, 8));
 
-        String bgColor = "#f8f9fa";
+        String bgColor = TaskStyleUtils.TINT_NEUTRAL;
         if (goal.isDelayed()) {
             bgColor = goal.getDelayColorIntensity() < 0.5 ? "#fff3cd" : "#f8d7da";
         }
@@ -981,7 +1034,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         Label attemptLabel = new Label(formatAttemptSummary(goal));
         attemptLabel.setStyle("-fx-text-fill: "
-                + (goal.getMissedAttemptCount() > 0 ? "#dc3545" : "#6c757d") + ";");
+                + (goal.getMissedAttemptCount() > 0 ? TaskStyleUtils.COLOR_DANGER : "#6c757d") + ";");
         TaskStyleUtils.fontNormal(attemptLabel, 11);
         textBox.getChildren().add(attemptLabel);
 
@@ -1002,7 +1055,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     }
 
     /**
-     * Builds a collapsible "Completed Attempts" section for achieved attempts.
+     * Builds a collapsible completed-goals section for achieved attempts.
      * Clicking the header toggles visibility of the completed goal rows.
      */
     private VBox buildCompletedGoalsSection(List<StudyGoal> completedGoals) {
@@ -1013,7 +1066,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         itemsBox.setVisible(false);
         itemsBox.setManaged(false);
 
-        Label toggle = new Label("Completed Attempts (" + completedGoals.size() + ")");
+        Label toggle = new Label("Completed Goals (" + completedGoals.size() + ")");
         toggle.setGraphic(TaskStyleUtils.iconLabel("\u25B6", 11));
         TaskStyleUtils.fontBold(toggle, 11);
         toggle.setTextFill(Color.web("#27ae60"));
@@ -1434,8 +1487,8 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         content.setMaxHeight(Region.USE_PREF_SIZE);
 
         Label headerLabel = new Label(linkedTask != null
-                ? "Add goal attempt for: " + linkedTask.getTitle()
-                : "Create a new study goal attempt");
+                ? "Add goal for: " + linkedTask.getTitle()
+                : "Create a new study goal");
         TaskStyleUtils.fontBold(headerLabel, 16);
 
         // Date
@@ -1455,7 +1508,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         dateRow.setAlignment(Pos.CENTER_LEFT);
 
         TextArea descArea = new TextArea();
-        descArea.setPromptText("Goal attempt description...");
+        descArea.setPromptText("Goal description...");
         descArea.setPrefRowCount(3);
         descArea.setWrapText(true);
 
@@ -1491,7 +1544,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
                     new Label("Description:"), descArea);
         }
 
-        Button okBtn = new Button("Add Goal Attempt");
+        Button okBtn = new Button("Add Goal");
         okBtn.getStyleClass().add("btn-purple");
         okBtn.setDisable(true);
         descArea.textProperty().addListener((obs, o, n) -> okBtn.setDisable(n.trim().isEmpty()));

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -21,10 +21,8 @@ import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.Node;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -258,7 +256,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         Label groupLabel = new Label("Group:");
         TaskStyleUtils.fontBold(groupLabel, 12);
         ComboBox<String> groupCombo = new ComboBox<>();
-        groupCombo.getItems().addAll("None", "Status", "Category", "Deadline");
+        groupCombo.getItems().addAll("None", "Status", "Category", "Reason");
         groupCombo.setValue(currentGroup);
         groupCombo.setOnAction(e -> {
             currentGroup = groupCombo.getValue();
@@ -587,40 +585,6 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
                 || status == TaskStatus.DELAYED;
     }
 
-    private boolean surfacesByDateRules(Task task, LocalDate date) {
-        if (task == null || date == null) {
-            return false;
-        }
-
-        TaskStatus status = task.getStatus();
-        boolean active = status == TaskStatus.OPEN || status == TaskStatus.IN_PROGRESS;
-        boolean delayed = status == TaskStatus.DELAYED;
-
-        if (task.isRecurring()) {
-            if (!active) {
-                return false;
-            }
-            if (task.getStartDate() != null && date.isBefore(task.getStartDate())) {
-                return false;
-            }
-            if (task.getDeadline() != null && date.isAfter(task.getDeadline())) {
-                return false;
-            }
-            LocalDate anchorMonday = task.getRecurrenceAnchor()
-                    .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-            return taskService.recurringTaskAppliesTo(task, date, anchorMonday);
-        }
-
-        if (!(active || delayed)) {
-            return false;
-        }
-        LocalDate deadline = task.getDeadline();
-        if (deadline == null) {
-            return date.equals(dateTimeService.getCurrentDate());
-        }
-        return !date.isBefore(deadline);
-    }
-
     private boolean hasGoalOnDisplayDate(Task task) {
         return task != null && taskIdsWithAttemptsOnDisplayDate.contains(task.getId());
     }
@@ -658,20 +622,20 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             case "Status" -> task.getStatus().name();
             case "Category" -> task.getCategory() != null && !task.getCategory().isBlank()
                     ? task.getCategory() : "Uncategorized";
-            case "Deadline", "Reason" -> reasonGroupKeyFor(task);
+            case "Reason" -> reasonGroupKeyFor(task);
             default -> "";
         };
     }
 
     private String reasonGroupKeyFor(Task task) {
-        if (task.isRecurring() && surfacesByDateRules(task, displayDate)) {
+        if (task.isRecurring() && taskService.taskSurfacesOn(task, displayDate)) {
             return "Recurring";
         }
         LocalDate deadline = task.getDeadline();
-        if (deadline != null && deadline.equals(displayDate) && surfacesByDateRules(task, displayDate)) {
+        if (deadline != null && deadline.equals(displayDate) && taskService.taskSurfacesOn(task, displayDate)) {
             return "Due";
         }
-        if (deadline != null && deadline.isBefore(displayDate) && surfacesByDateRules(task, displayDate)) {
+        if (deadline != null && deadline.isBefore(displayDate) && taskService.taskSurfacesOn(task, displayDate)) {
             return "Overdue";
         }
         if (hasGoalOnDisplayDate(task)) {

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -14,8 +14,6 @@ import com.studysync.domain.entity.Task;
 import com.studysync.domain.valueobject.TaskCategory;
 import com.studysync.domain.valueobject.TaskPriority;
 import com.studysync.domain.valueobject.TaskStatus;
-import javafx.application.Platform;
-import javafx.util.Callback;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.*;
@@ -23,8 +21,10 @@ import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.Node;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -66,13 +66,20 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     // Tracks which task cards are currently expanded so they survive UI rebuilds
     private final Set<String> expandedTaskIds = new HashSet<>();
 
+    private enum PlannerTaskView {
+        TODAY,
+        ALL_TASKS
+    }
+
     // Sort / group state for the tasks section
     private String currentSort = "Status";
     private String currentGroup = "None";
+    private PlannerTaskView currentTaskView = PlannerTaskView.TODAY;
 
     // UI containers that get rebuilt on navigation
     private VBox tasksContainer;
     private FlowPane attemptOverviewContainer;
+    private Label taskSectionTitle;
     private FlowPane sessionsFlowPane;
     private TextArea reflectionArea;
     private ProgressBar dailyProgressBar;
@@ -189,9 +196,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox sectionHeader = new HBox(15);
         sectionHeader.setAlignment(Pos.CENTER_LEFT);
 
-        Label sectionTitle = new Label("Today's Tasks & Goal Attempts");
-        sectionTitle.setGraphic(TaskStyleUtils.iconLabel("\u2611", 18));
-        TaskStyleUtils.fontBold(sectionTitle, 18);
+        taskSectionTitle = new Label("Today's Tasks & Goal Attempts");
+        taskSectionTitle.setGraphic(TaskStyleUtils.iconLabel("\u2611", 18));
+        TaskStyleUtils.fontBold(taskSectionTitle, 18);
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
@@ -200,7 +207,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         addGoalBtn.getStyleClass().add("btn-purple");
         addGoalBtn.setOnAction(e -> showAddGoalDialog(null));
 
-        sectionHeader.getChildren().addAll(sectionTitle, spacer, addGoalBtn);
+        sectionHeader.getChildren().addAll(taskSectionTitle, spacer, addGoalBtn);
 
         attemptOverviewContainer = new FlowPane();
         attemptOverviewContainer.setHgap(10);
@@ -211,21 +218,52 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox toolbar = new HBox(10);
         toolbar.setAlignment(Pos.CENTER_LEFT);
 
+        ToggleButton todayViewBtn = new ToggleButton("Today");
+        ToggleButton allTasksViewBtn = new ToggleButton("All Tasks");
+        ToggleGroup viewGroup = new ToggleGroup();
+        todayViewBtn.setToggleGroup(viewGroup);
+        allTasksViewBtn.setToggleGroup(viewGroup);
+        todayViewBtn.setSelected(currentTaskView == PlannerTaskView.TODAY);
+        allTasksViewBtn.setSelected(currentTaskView == PlannerTaskView.ALL_TASKS);
+        todayViewBtn.getStyleClass().addAll("btn-gray", "btn-small");
+        allTasksViewBtn.getStyleClass().addAll("btn-gray", "btn-small");
+        todayViewBtn.setOnAction(e -> {
+            if (!todayViewBtn.isSelected()) {
+                todayViewBtn.setSelected(true);
+            }
+            currentTaskView = PlannerTaskView.TODAY;
+            updateTasksDisplay();
+        });
+        allTasksViewBtn.setOnAction(e -> {
+            if (!allTasksViewBtn.isSelected()) {
+                allTasksViewBtn.setSelected(true);
+            }
+            currentTaskView = PlannerTaskView.ALL_TASKS;
+            updateTasksDisplay();
+        });
+
         Label sortLabel = new Label("Sort:");
         TaskStyleUtils.fontBold(sortLabel, 12);
         ComboBox<String> sortCombo = new ComboBox<>();
         sortCombo.getItems().addAll("Status", "Priority", "Deadline", "Title");
         sortCombo.setValue(currentSort);
-        sortCombo.setOnAction(e -> { currentSort = sortCombo.getValue(); updateTasksDisplay(); });
+        sortCombo.setOnAction(e -> {
+            currentSort = sortCombo.getValue();
+            updateTasksDisplay();
+        });
 
         Label groupLabel = new Label("Group:");
         TaskStyleUtils.fontBold(groupLabel, 12);
         ComboBox<String> groupCombo = new ComboBox<>();
-        groupCombo.getItems().addAll("None", "Status", "Category");
+        groupCombo.getItems().addAll("None", "Status", "Category", "Reason");
         groupCombo.setValue(currentGroup);
-        groupCombo.setOnAction(e -> { currentGroup = groupCombo.getValue(); updateTasksDisplay(); });
+        groupCombo.setOnAction(e -> {
+            currentGroup = groupCombo.getValue();
+            updateTasksDisplay();
+        });
 
-        toolbar.getChildren().addAll(sortLabel, sortCombo, groupLabel, groupCombo);
+        toolbar.getChildren().addAll(
+                todayViewBtn, allTasksViewBtn, sortLabel, sortCombo, groupLabel, groupCombo);
 
         tasksContainer = new VBox(10);
         section.getChildren().addAll(sectionHeader, attemptOverviewContainer, toolbar, tasksContainer);
@@ -321,15 +359,30 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     private void updateTasksDisplay() {
         tasksContainer.getChildren().clear();
 
-        List<Task> tasks = new ArrayList<>(taskService.getTasksForDate(displayDate));
+        if (taskSectionTitle != null) {
+            taskSectionTitle.setText(currentTaskView == PlannerTaskView.TODAY
+                    ? "Today's Tasks & Goal Attempts" : "All Active Tasks");
+        }
+
+        List<Task> tasks = new ArrayList<>(tasksForCurrentView());
         LocalDate today = dateTimeService.getCurrentDate();
-        updateAttemptOverview();
+        boolean dateScopedView = currentTaskView == PlannerTaskView.TODAY;
+        if (attemptOverviewContainer != null) {
+            attemptOverviewContainer.setVisible(dateScopedView);
+            attemptOverviewContainer.setManaged(dateScopedView);
+            if (dateScopedView) {
+                updateAttemptOverview();
+            } else {
+                attemptOverviewContainer.getChildren().clear();
+            }
+        }
 
         if (tasks.isEmpty()) {
             // No tasks for this day — offer "Create Task" shortcut
             VBox emptyBox = new VBox(8);
             emptyBox.setAlignment(Pos.CENTER_LEFT);
-            Label emptyLabel = new Label("No tasks scheduled for this day.");
+            Label emptyLabel = new Label(dateScopedView
+                    ? "No tasks scheduled for this day." : "No active tasks.");
             TaskStyleUtils.fontNormal(emptyLabel, 14);
             emptyLabel.setTextFill(Color.web("#7f8c8d"));
 
@@ -339,7 +392,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
             emptyBox.getChildren().addAll(emptyLabel, createTaskBtn);
             tasksContainer.getChildren().add(emptyBox);
-            // Do NOT return — unlinked goals and re-plan section must still render
+            // Do NOT return — unlinked goals must still render in the date-scoped view
         } else {
             // Apply user-selected sort order
             tasks.sort(taskSortComparator());
@@ -369,7 +422,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         }
 
         // Missed recurring-task occurrences (carry-forward to today)
-        if (displayDate.equals(today)) {
+        if (dateScopedView && displayDate.equals(today)) {
             List<MissedOccurrence> missed = taskService.getMissedRecurringOccurrences(today);
             Set<String> shownTaskIds = tasks.stream().map(Task::getId).collect(Collectors.toSet());
             LinkedHashMap<String, List<MissedOccurrence>> byTask = new LinkedHashMap<>();
@@ -398,31 +451,28 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         }
 
         // Unlinked attempts section (goals with no task)
-        List<StudyGoal> allUnlinked = StudyGoal.findUnlinkedForDate(displayDate);
-        List<StudyGoal> unlinkedGoals = allUnlinked.stream()
-                .filter(g -> !g.isAchieved()).toList();
-        List<StudyGoal> completedUnlinked = allUnlinked.stream()
-                .filter(StudyGoal::isAchieved).toList();
-        if (!unlinkedGoals.isEmpty() || !completedUnlinked.isEmpty()) {
-            VBox unlinkedSection = new VBox(6);
-            unlinkedSection.setPadding(new Insets(10, 0, 0, 0));
-            Label unlinkedTitle = new Label("Goal attempts without a task:");
-            TaskStyleUtils.fontBold(unlinkedTitle, 13);
-            unlinkedTitle.setTextFill(Color.web("#6c757d"));
-            unlinkedSection.getChildren().add(unlinkedTitle);
-            for (StudyGoal goal : unlinkedGoals) {
-                unlinkedSection.getChildren().add(buildGoalRow(goal, null));
+        if (dateScopedView) {
+            List<StudyGoal> allUnlinked = StudyGoal.findUnlinkedForDate(displayDate);
+            List<StudyGoal> unlinkedGoals = allUnlinked.stream()
+                    .filter(g -> !g.isAchieved()).toList();
+            List<StudyGoal> completedUnlinked = allUnlinked.stream()
+                    .filter(StudyGoal::isAchieved).toList();
+            if (!unlinkedGoals.isEmpty() || !completedUnlinked.isEmpty()) {
+                VBox unlinkedSection = new VBox(6);
+                unlinkedSection.setPadding(new Insets(10, 0, 0, 0));
+                Label unlinkedTitle = new Label("Goal attempts without a task:");
+                TaskStyleUtils.fontBold(unlinkedTitle, 13);
+                unlinkedTitle.setTextFill(Color.web("#6c757d"));
+                unlinkedSection.getChildren().add(unlinkedTitle);
+                for (StudyGoal goal : unlinkedGoals) {
+                    unlinkedSection.getChildren().add(buildGoalRow(goal, null));
+                }
+                if (!completedUnlinked.isEmpty()) {
+                    unlinkedSection.getChildren().add(
+                            buildCompletedGoalsSection(completedUnlinked));
+                }
+                tasksContainer.getChildren().add(unlinkedSection);
             }
-            if (!completedUnlinked.isEmpty()) {
-                unlinkedSection.getChildren().add(
-                        buildCompletedGoalsSection(completedUnlinked));
-            }
-            tasksContainer.getChildren().add(unlinkedSection);
-        }
-
-        // Re-plan section — only available when viewing today
-        if (displayDate.equals(today)) {
-            tasksContainer.getChildren().add(buildReplanSection());
         }
     }
 
@@ -484,6 +534,63 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         return studyService.getAllGoalsForDate(displayDate);
     }
 
+    private List<Task> tasksForCurrentView() {
+        if (currentTaskView == PlannerTaskView.ALL_TASKS) {
+            return taskService.getTasks().stream()
+                    .filter(this::isActivePlannerTask)
+                    .toList();
+        }
+        return taskService.getTasksForDate(displayDate);
+    }
+
+    private boolean isActivePlannerTask(Task task) {
+        TaskStatus status = task.getStatus();
+        return status == TaskStatus.OPEN
+                || status == TaskStatus.IN_PROGRESS
+                || status == TaskStatus.DELAYED;
+    }
+
+    private boolean surfacesByDateRules(Task task, LocalDate date) {
+        if (task == null || date == null) {
+            return false;
+        }
+
+        TaskStatus status = task.getStatus();
+        boolean active = status == TaskStatus.OPEN || status == TaskStatus.IN_PROGRESS;
+        boolean delayed = status == TaskStatus.DELAYED;
+
+        if (task.isRecurring()) {
+            if (!active) {
+                return false;
+            }
+            if (task.getStartDate() != null && date.isBefore(task.getStartDate())) {
+                return false;
+            }
+            if (task.getDeadline() != null && date.isAfter(task.getDeadline())) {
+                return false;
+            }
+            LocalDate anchorMonday = task.getRecurrenceAnchor()
+                    .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            return taskService.recurringTaskAppliesTo(task, date, anchorMonday);
+        }
+
+        if (!(active || delayed)) {
+            return false;
+        }
+        LocalDate deadline = task.getDeadline();
+        if (deadline == null) {
+            return date.equals(dateTimeService.getCurrentDate());
+        }
+        return !date.isBefore(deadline);
+    }
+
+    private boolean hasGoalOnDisplayDate(Task task) {
+        return task != null
+                && StudyGoal.findByTaskIdForDate(task.getId(), displayDate).stream()
+                        .findAny()
+                        .isPresent();
+    }
+
     /** Returns a comparator based on the user's current sort choice. */
     private Comparator<Task> taskSortComparator() {
         return switch (currentSort) {
@@ -517,122 +624,33 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             case "Status" -> task.getStatus().name();
             case "Category" -> task.getCategory() != null && !task.getCategory().isBlank()
                     ? task.getCategory() : "Uncategorized";
+            case "Reason" -> reasonGroupKeyFor(task);
             default -> "";
         };
     }
 
-    /**
-     * Builds the retry section for missed goal attempts.
-     * Shows a ComboBox of missed attempts whose parent goal can be tried again.
-     */
-    private VBox buildReplanSection() {
-        List<StudyGoal> candidates = studyService.getDelayedGoalsForReplanning();
-
-        VBox section = new VBox(8);
-        section.setPadding(new Insets(14, 0, 0, 0));
-
-        // Collapsible header row
-        Label header = new Label("Plan a Retry for a Missed Goal");
-        header.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 13));
-        TaskStyleUtils.fontBold(header, 13);
-        header.setTextFill(Color.web("#6c757d"));
-
-        if (candidates.isEmpty()) {
-            Label none = new Label("No missed goal attempts available to retry.");
-            TaskStyleUtils.fontNormal(none, 12);
-            none.setTextFill(Color.web("#7f8c8d"));
-            section.getChildren().addAll(header, none);
-            return section;
+    private String reasonGroupKeyFor(Task task) {
+        if (task.isRecurring() && surfacesByDateRules(task, displayDate)) {
+            return "Recurring today";
         }
-
-        // Preload task titles once to avoid DB lookups during ComboBox cell rendering.
-        Map<String, String> taskTitles = new LinkedHashMap<>();
-        for (StudyGoal goal : candidates) {
-            String taskId = goal.getTaskId();
-            if (taskId == null || taskId.isBlank() || taskTitles.containsKey(taskId)) {
-                continue;
-            }
-            Task.findById(taskId).ifPresent(t -> taskTitles.put(taskId, t.getTitle()));
+        LocalDate deadline = task.getDeadline();
+        if (deadline != null && deadline.equals(displayDate) && surfacesByDateRules(task, displayDate)) {
+            return "Due today";
         }
-
-        ComboBox<StudyGoal> combo = new ComboBox<>();
-        combo.getItems().addAll(candidates);
-        combo.setVisibleRowCount(Math.max(1, Math.min(candidates.size(), 8)));
-        combo.setMaxWidth(Double.MAX_VALUE);
-        combo.setOnShowing(e -> combo.setVisibleRowCount(Math.max(1, Math.min(candidates.size(), 8))));
-        combo.setOnShown(e -> sizeComboPopupToRows(combo, candidates.size()));
-        Callback<ListView<StudyGoal>, ListCell<StudyGoal>> cellFactory = lv -> new ListCell<>() {
-            @Override
-            protected void updateItem(StudyGoal goal, boolean empty) {
-                super.updateItem(goal, empty);
-                if (empty || goal == null) {
-                    setText(null);
-                    setGraphic(null);
-                } else {
-                    setText(formatDelayedGoal(goal, taskTitles));
-                    setGraphic(null);
-                }
-            }
-        };
-        combo.setCellFactory(cellFactory);
-        combo.setButtonCell(cellFactory.call(null));
-        combo.setPromptText("Select a missed goal to retry...");
-
-        Button replanBtn = new Button("Plan Retry Today");
-        replanBtn.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 13));
-        replanBtn.getStyleClass().addAll("btn-orange", "btn-small");
-        replanBtn.setDisable(true);
-
-        combo.setOnAction(e -> replanBtn.setDisable(combo.getValue() == null));
-
-        replanBtn.setOnAction(e -> {
-            StudyGoal selected = combo.getValue();
-            if (selected == null) return;
-            studyService.replanGoalForToday(selected.getId());
-            updateTasksDisplay();
-            updateProgress();
-        });
-
-        HBox controls = new HBox(8, combo, replanBtn);
-        controls.setAlignment(Pos.CENTER_LEFT);
-        HBox.setHgrow(combo, Priority.ALWAYS);
-
-        section.getChildren().addAll(header, controls);
-        return section;
-    }
-
-    /** Formats a missed attempt for display in the retry ComboBox. */
-    private String formatDelayedGoal(StudyGoal goal, Map<String, String> taskTitles) {
-        String taskLabel = "";
-        String taskId = goal.getTaskId();
-        if (taskId != null && !taskId.isBlank()) {
-            String title = taskTitles.get(taskId);
-            if (title != null && !title.isBlank()) {
-                taskLabel = title + ": ";
-            }
+        if (deadline != null && deadline.isBefore(displayDate) && surfacesByDateRules(task, displayDate)) {
+            return "Overdue";
         }
-        String desc = goal.getDescription();
-        if (desc != null && desc.length() > 60) {
-            desc = desc.substring(0, 57) + "...";
+        if (hasGoalOnDisplayDate(task)) {
+            return "Has goal today";
         }
-        int misses = goal.getMissedAttemptCount();
-        int nextAttempt = Math.max(goal.getAttemptNumber() + 1, misses + 2);
-        return taskLabel + desc + " (attempt " + nextAttempt + ")";
-    }
-
-    private void sizeComboPopupToRows(ComboBox<?> combo, int itemCount) {
-        Platform.runLater(() -> {
-            Node popupContent = combo.lookup(".list-view");
-            if (popupContent instanceof ListView<?> listView) {
-                double rowHeight = 28.0;
-                int visibleRows = Math.max(1, Math.min(itemCount, 8));
-                double height = visibleRows * rowHeight + 2;
-                listView.setFixedCellSize(rowHeight);
-                listView.setMinHeight(height);
-                listView.setPrefHeight(height);
-                listView.setMaxHeight(height);
-            }
-        });
+        if (currentTaskView == PlannerTaskView.TODAY
+                && !task.isRecurring()
+                && deadline == null
+                && isActivePlannerTask(task)
+                && displayDate.equals(dateTimeService.getCurrentDate())) {
+            return "Open (no deadline)";
+        }
+        return "Other active tasks";
     }
 
     /**
@@ -818,20 +836,25 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         List<StudyGoal> allGoals = StudyGoal.findByTaskIdForDate(task.getId(), displayDate);
         List<StudyGoal> activeGoals = allGoals.stream().filter(g -> !g.isAchieved()).toList();
         List<StudyGoal> completedGoals = allGoals.stream().filter(StudyGoal::isAchieved).toList();
+        VBox retrySection = buildTaskRetrySection(task);
 
         if (activeGoals.isEmpty() && completedGoals.isEmpty()) {
-            Label noGoals = new Label("No goal attempts linked to this task for this date.");
-            TaskStyleUtils.fontNormal(noGoals, 12);
-            noGoals.setTextFill(Color.web("#7f8c8d"));
+            if (retrySection != null) {
+                goalsPanel.getChildren().add(retrySection);
+            } else {
+                Label noGoals = new Label("No goal attempts linked to this task for this date.");
+                TaskStyleUtils.fontNormal(noGoals, 12);
+                noGoals.setTextFill(Color.web("#7f8c8d"));
 
-            Button addGoalBtn = new Button("+ Create Goal Attempt");
-            addGoalBtn.getStyleClass().addAll("btn-purple", "btn-small");
-            addGoalBtn.setOnAction(e -> {
-                showAddGoalDialog(task);
-                populateGoalsPanel(goalsPanel, task); // refresh after add
-            });
+                Button addGoalBtn = new Button("+ Create Goal Attempt");
+                addGoalBtn.getStyleClass().addAll("btn-purple", "btn-small");
+                addGoalBtn.setOnAction(e -> {
+                    showAddGoalDialog(task);
+                    populateGoalsPanel(goalsPanel, task); // refresh after add
+                });
 
-            goalsPanel.getChildren().addAll(noGoals, addGoalBtn);
+                goalsPanel.getChildren().addAll(noGoals, addGoalBtn);
+            }
         } else {
             for (StudyGoal goal : activeGoals) {
                 goalsPanel.getChildren().add(buildGoalRow(goal, task));
@@ -850,6 +873,73 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             goalsPanel.getChildren().add(
                     buildCompletedGoalsSection(completedGoals));
         }
+
+        if (retrySection != null && (!activeGoals.isEmpty() || !completedGoals.isEmpty())) {
+            goalsPanel.getChildren().add(retrySection);
+        }
+    }
+
+    private VBox buildTaskRetrySection(Task task) {
+        if (!displayDate.equals(dateTimeService.getCurrentDate())) {
+            return null;
+        }
+        List<StudyGoal> retryableGoals = studyService.getDelayedGoalsForReplanning(task.getId());
+        if (retryableGoals.isEmpty()) {
+            return null;
+        }
+
+        VBox section = new VBox(6);
+        section.setPadding(new Insets(8, 0, 0, 0));
+
+        Label header = new Label("Missed attempts ready to retry");
+        header.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 12));
+        TaskStyleUtils.fontBold(header, 12);
+        header.setTextFill(Color.web("#d35400"));
+        section.getChildren().add(header);
+
+        for (StudyGoal goal : retryableGoals) {
+            section.getChildren().add(buildTaskRetryRow(goal));
+        }
+        return section;
+    }
+
+    private HBox buildTaskRetryRow(StudyGoal goal) {
+        HBox row = new HBox(10);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.setPadding(new Insets(6, 8, 6, 8));
+        row.setStyle("-fx-background-color: #fff3e0; -fx-background-radius: 5;");
+
+        VBox textBox = new VBox(2);
+        Label goalLabel = new Label(goal.getDescription());
+        TaskStyleUtils.fontNormal(goalLabel, 13);
+        Label attemptLabel = new Label(formatRetryAttemptSummary(goal));
+        TaskStyleUtils.fontNormal(attemptLabel, 11);
+        attemptLabel.setTextFill(Color.web("#d35400"));
+        textBox.getChildren().addAll(goalLabel, attemptLabel);
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        Button replanBtn = new Button("Plan retry today");
+        replanBtn.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 12));
+        replanBtn.getStyleClass().addAll("btn-orange", "btn-small");
+        replanBtn.setOnAction(e -> {
+            studyService.replanGoalForToday(goal.getId());
+            updateTasksDisplay();
+            updateProgress();
+        });
+
+        row.getChildren().addAll(textBox, spacer, replanBtn);
+        return row;
+    }
+
+    private String formatRetryAttemptSummary(StudyGoal goal) {
+        String missedOn = goal.getDate() != null
+                ? goal.getDate().format(DateTimeFormatter.ofPattern("MMM d"))
+                : "previous attempt";
+        int nextAttempt = Math.max(goal.getAttemptNumber() + 1, goal.getMissedAttemptCount() + 2);
+        return "Missed " + missedOn + " - " + formatAttemptSummary(goal)
+                + " - next attempt " + nextAttempt;
     }
 
     private HBox buildGoalRow(StudyGoal goal, Task linkedTask) {

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -14,6 +14,7 @@ import com.studysync.domain.entity.Task;
 import com.studysync.domain.valueobject.TaskCategory;
 import com.studysync.domain.valueobject.TaskPriority;
 import com.studysync.domain.valueobject.TaskStatus;
+import javafx.application.Platform;
 import javafx.util.Callback;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -71,6 +72,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
     // UI containers that get rebuilt on navigation
     private VBox tasksContainer;
+    private FlowPane attemptOverviewContainer;
     private FlowPane sessionsFlowPane;
     private TextArea reflectionArea;
     private ProgressBar dailyProgressBar;
@@ -187,18 +189,23 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox sectionHeader = new HBox(15);
         sectionHeader.setAlignment(Pos.CENTER_LEFT);
 
-        Label sectionTitle = new Label("Today's Tasks");
+        Label sectionTitle = new Label("Today's Tasks & Goal Attempts");
         sectionTitle.setGraphic(TaskStyleUtils.iconLabel("\u2611", 18));
         TaskStyleUtils.fontBold(sectionTitle, 18);
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
-        Button addGoalBtn = new Button("+ Add Goal");
+        Button addGoalBtn = new Button("+ Add Goal Attempt");
         addGoalBtn.getStyleClass().add("btn-purple");
         addGoalBtn.setOnAction(e -> showAddGoalDialog(null));
 
         sectionHeader.getChildren().addAll(sectionTitle, spacer, addGoalBtn);
+
+        attemptOverviewContainer = new FlowPane();
+        attemptOverviewContainer.setHgap(10);
+        attemptOverviewContainer.setVgap(8);
+        attemptOverviewContainer.setAlignment(Pos.CENTER_LEFT);
 
         // Sort / group toolbar
         HBox toolbar = new HBox(10);
@@ -221,7 +228,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         toolbar.getChildren().addAll(sortLabel, sortCombo, groupLabel, groupCombo);
 
         tasksContainer = new VBox(10);
-        section.getChildren().addAll(sectionHeader, toolbar, tasksContainer);
+        section.getChildren().addAll(sectionHeader, attemptOverviewContainer, toolbar, tasksContainer);
         mainContent.getChildren().add(section);
     }
 
@@ -316,6 +323,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         List<Task> tasks = new ArrayList<>(taskService.getTasksForDate(displayDate));
         LocalDate today = dateTimeService.getCurrentDate();
+        updateAttemptOverview();
 
         if (tasks.isEmpty()) {
             // No tasks for this day — offer "Create Task" shortcut
@@ -389,7 +397,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             }
         }
 
-        // Unlinked goals section (goals with no task)
+        // Unlinked attempts section (goals with no task)
         List<StudyGoal> allUnlinked = StudyGoal.findUnlinkedForDate(displayDate);
         List<StudyGoal> unlinkedGoals = allUnlinked.stream()
                 .filter(g -> !g.isAchieved()).toList();
@@ -398,7 +406,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         if (!unlinkedGoals.isEmpty() || !completedUnlinked.isEmpty()) {
             VBox unlinkedSection = new VBox(6);
             unlinkedSection.setPadding(new Insets(10, 0, 0, 0));
-            Label unlinkedTitle = new Label("Goals without a task:");
+            Label unlinkedTitle = new Label("Goal attempts without a task:");
             TaskStyleUtils.fontBold(unlinkedTitle, 13);
             unlinkedTitle.setTextFill(Color.web("#6c757d"));
             unlinkedSection.getChildren().add(unlinkedTitle);
@@ -416,6 +424,64 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         if (displayDate.equals(today)) {
             tasksContainer.getChildren().add(buildReplanSection());
         }
+    }
+
+    private void updateAttemptOverview() {
+        if (attemptOverviewContainer == null) {
+            return;
+        }
+        attemptOverviewContainer.getChildren().clear();
+
+        List<StudyGoal> attempts = getAllAttemptsForDisplayDate();
+        long pending = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING)
+                .count();
+        long achieved = attempts.stream().filter(StudyGoal::isAchieved).count();
+        long missed = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.MISSED)
+                .count();
+        long retrying = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING
+                        && goal.getMissedAttemptCount() > 0)
+                .count();
+        int score = (int) (achieved - missed);
+
+        attemptOverviewContainer.getChildren().addAll(
+                createAttemptMetricCard("Attempts Today", String.valueOf(attempts.size()), "#3949ab", "#e8eaf6"),
+                createAttemptMetricCard("Pending", String.valueOf(pending), "#0d47a1", "#e3f2fd"),
+                createAttemptMetricCard("Retries", String.valueOf(retrying), "#e65100", "#fff3e0"),
+                createAttemptMetricCard("Achieved", String.valueOf(achieved), "#1b5e20", "#e8f5e9"),
+                createAttemptMetricCard("Missed", String.valueOf(missed), "#b71c1c", "#ffebee"),
+                createAttemptMetricCard("Score", String.format("%+d", score), "#4a148c", "#f3e5f5")
+        );
+    }
+
+    private VBox createAttemptMetricCard(String title, String value, String textColor, String backgroundColor) {
+        VBox card = new VBox(2);
+        card.setAlignment(Pos.CENTER_LEFT);
+        card.setMinWidth(105);
+        card.setPadding(new Insets(8, 10, 8, 10));
+        card.setStyle("-fx-background-color: " + backgroundColor + "; -fx-background-radius: 8;"
+                + " -fx-border-color: #d6dbe0; -fx-border-radius: 8;");
+
+        Label valueLabel = new Label(value);
+        TaskStyleUtils.fontBold(valueLabel, 18);
+        valueLabel.setTextFill(Color.web(textColor));
+
+        Label titleLabel = new Label(title);
+        TaskStyleUtils.fontNormal(titleLabel, 10);
+        titleLabel.setTextFill(Color.web(textColor));
+
+        card.getChildren().addAll(valueLabel, titleLabel);
+        return card;
+    }
+
+    private List<StudyGoal> getAllAttemptsForDisplayDate() {
+        LocalDate today = dateTimeService.getCurrentDate();
+        if (displayDate.isAfter(today)) {
+            return studyService.getAllGoalsForFutureDate(displayDate);
+        }
+        return studyService.getAllGoalsForDate(displayDate);
     }
 
     /** Returns a comparator based on the user's current sort choice. */
@@ -456,9 +522,8 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     }
 
     /**
-     * Builds the "Re-plan a delayed goal for today" section.
-     * Shows a ComboBox of delayed goals (from non-cancelled/non-postponed tasks)
-     * and a button to reschedule the selected goal to appear today exactly once.
+     * Builds the retry section for missed goal attempts.
+     * Shows a ComboBox of missed attempts whose parent goal can be tried again.
      */
     private VBox buildReplanSection() {
         List<StudyGoal> candidates = studyService.getDelayedGoalsForReplanning();
@@ -467,13 +532,13 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         section.setPadding(new Insets(14, 0, 0, 0));
 
         // Collapsible header row
-        Label header = new Label("Re-plan a Delayed Goal");
+        Label header = new Label("Plan a Retry for a Missed Goal");
         header.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 13));
         TaskStyleUtils.fontBold(header, 13);
         header.setTextFill(Color.web("#6c757d"));
 
         if (candidates.isEmpty()) {
-            Label none = new Label("No delayed goals available to re-plan.");
+            Label none = new Label("No missed goal attempts available to retry.");
             TaskStyleUtils.fontNormal(none, 12);
             none.setTextFill(Color.web("#7f8c8d"));
             section.getChildren().addAll(header, none);
@@ -492,8 +557,10 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         ComboBox<StudyGoal> combo = new ComboBox<>();
         combo.getItems().addAll(candidates);
-        combo.setVisibleRowCount(Math.min(candidates.size(), 15));
+        combo.setVisibleRowCount(Math.max(1, Math.min(candidates.size(), 8)));
         combo.setMaxWidth(Double.MAX_VALUE);
+        combo.setOnShowing(e -> combo.setVisibleRowCount(Math.max(1, Math.min(candidates.size(), 8))));
+        combo.setOnShown(e -> sizeComboPopupToRows(combo, candidates.size()));
         Callback<ListView<StudyGoal>, ListCell<StudyGoal>> cellFactory = lv -> new ListCell<>() {
             @Override
             protected void updateItem(StudyGoal goal, boolean empty) {
@@ -509,9 +576,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         };
         combo.setCellFactory(cellFactory);
         combo.setButtonCell(cellFactory.call(null));
-        combo.setPromptText("Select a delayed goal to re-plan...");
+        combo.setPromptText("Select a missed goal to retry...");
 
-        Button replanBtn = new Button("Re-plan for Today");
+        Button replanBtn = new Button("Plan Retry Today");
         replanBtn.setGraphic(TaskStyleUtils.iconLabel("\u21BA", 13));
         replanBtn.getStyleClass().addAll("btn-orange", "btn-small");
         replanBtn.setDisable(true);
@@ -534,7 +601,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         return section;
     }
 
-    /** Formats a delayed goal for display in the re-plan ComboBox. */
+    /** Formats a missed attempt for display in the retry ComboBox. */
     private String formatDelayedGoal(StudyGoal goal, Map<String, String> taskTitles) {
         String taskLabel = "";
         String taskId = goal.getTaskId();
@@ -549,8 +616,23 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             desc = desc.substring(0, 57) + "...";
         }
         int misses = goal.getMissedAttemptCount();
-        String missLabel = misses == 1 ? "1 prior miss" : misses + " prior misses";
-        return taskLabel + desc + " (attempt " + (goal.getAttemptNumber() + 1) + ", " + missLabel + ")";
+        int nextAttempt = Math.max(goal.getAttemptNumber() + 1, misses + 2);
+        return taskLabel + desc + " (attempt " + nextAttempt + ")";
+    }
+
+    private void sizeComboPopupToRows(ComboBox<?> combo, int itemCount) {
+        Platform.runLater(() -> {
+            Node popupContent = combo.lookup(".list-view");
+            if (popupContent instanceof ListView<?> listView) {
+                double rowHeight = 28.0;
+                int visibleRows = Math.max(1, Math.min(itemCount, 8));
+                double height = visibleRows * rowHeight + 2;
+                listView.setFixedCellSize(rowHeight);
+                listView.setMinHeight(height);
+                listView.setPrefHeight(height);
+                listView.setMaxHeight(height);
+            }
+        });
     }
 
     /**
@@ -596,7 +678,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
         headerRow.getChildren().addAll(0, List.of(arrow)); // arrow first
-        headerRow.getChildren().addAll(taskTitle, priorityLabel, spacer);
+        headerRow.getChildren().addAll(taskTitle, priorityLabel);
+        headerRow.getChildren().addAll(createTaskAttemptBadges(task));
+        headerRow.getChildren().add(spacer);
 
         // Overdue / due-today badge (between spacer and status badge)
         if (TaskStyleUtils.isOverdue(task, displayDate)) {
@@ -636,6 +720,50 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
         card.getChildren().addAll(headerRow, goalsPanel);
         return card;
+    }
+
+    private List<Label> createTaskAttemptBadges(Task task) {
+        List<StudyGoal> attempts = StudyGoal.findByTaskId(task.getId()).stream()
+                .filter(goal -> displayDate.equals(goal.getDate()))
+                .toList();
+        if (attempts.isEmpty()) {
+            return List.of();
+        }
+
+        long pending = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING)
+                .count();
+        long achieved = attempts.stream().filter(StudyGoal::isAchieved).count();
+        long missed = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.MISSED)
+                .count();
+        long retries = attempts.stream().filter(goal -> goal.getMissedAttemptCount() > 0).count();
+
+        List<Label> badges = new ArrayList<>();
+        badges.add(createTaskAttemptBadge(attempts.size() + " attempt" + (attempts.size() == 1 ? "" : "s"),
+                "#3949ab", "#e8eaf6"));
+        if (pending > 0) {
+            badges.add(createTaskAttemptBadge(pending + " pending", "#0d47a1", "#e3f2fd"));
+        }
+        if (retries > 0) {
+            badges.add(createTaskAttemptBadge(retries + " retry", "#e65100", "#fff3e0"));
+        }
+        if (achieved > 0) {
+            badges.add(createTaskAttemptBadge(achieved + " done", "#1b5e20", "#e8f5e9"));
+        }
+        if (missed > 0) {
+            badges.add(createTaskAttemptBadge(missed + " missed", "#b71c1c", "#ffebee"));
+        }
+        return badges;
+    }
+
+    private Label createTaskAttemptBadge(String text, String textColor, String backgroundColor) {
+        Label badge = new Label(text);
+        TaskStyleUtils.fontBold(badge, 10);
+        badge.setTextFill(Color.web(textColor));
+        badge.setPadding(new Insets(2, 7, 2, 7));
+        badge.setStyle("-fx-background-color: " + backgroundColor + "; -fx-background-radius: 10;");
+        return badge;
     }
 
     /**
@@ -692,11 +820,11 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         List<StudyGoal> completedGoals = allGoals.stream().filter(StudyGoal::isAchieved).toList();
 
         if (activeGoals.isEmpty() && completedGoals.isEmpty()) {
-            Label noGoals = new Label("No goals linked to this task yet.");
+            Label noGoals = new Label("No goal attempts linked to this task for this date.");
             TaskStyleUtils.fontNormal(noGoals, 12);
             noGoals.setTextFill(Color.web("#7f8c8d"));
 
-            Button addGoalBtn = new Button("+ Create Goal");
+            Button addGoalBtn = new Button("+ Create Goal Attempt");
             addGoalBtn.getStyleClass().addAll("btn-purple", "btn-small");
             addGoalBtn.setOnAction(e -> {
                 showAddGoalDialog(task);
@@ -708,7 +836,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             for (StudyGoal goal : activeGoals) {
                 goalsPanel.getChildren().add(buildGoalRow(goal, task));
             }
-            Button addMoreBtn = new Button("+ Add Goal");
+            Button addMoreBtn = new Button("+ Add Goal Attempt");
             addMoreBtn.getStyleClass().addAll("btn-purple", "btn-small");
             addMoreBtn.setOnAction(e -> {
                 showAddGoalDialog(task);
@@ -717,7 +845,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             goalsPanel.getChildren().add(addMoreBtn);
         }
 
-        // Completed goals — collapsible section
+        // Completed attempts - collapsible section
         if (!completedGoals.isEmpty()) {
             goalsPanel.getChildren().add(
                     buildCompletedGoalsSection(completedGoals));
@@ -751,22 +879,30 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         TaskStyleUtils.fontNormal(goalLabel, 13);
         textBox.getChildren().add(goalLabel);
 
-        if (goal.isDelayed()) {
-            Label delayLabel = new Label(String.format("Attempt %d (%d prior miss%s)",
-                    goal.getAttemptNumber(),
-                    goal.getMissedAttemptCount(),
-                    goal.getMissedAttemptCount() == 1 ? "" : "es"));
-            delayLabel.setStyle("-fx-text-fill: #dc3545;");
-            TaskStyleUtils.fontNormal(delayLabel, 11);
-            textBox.getChildren().add(delayLabel);
-        }
+        Label attemptLabel = new Label(formatAttemptSummary(goal));
+        attemptLabel.setStyle("-fx-text-fill: "
+                + (goal.getMissedAttemptCount() > 0 ? "#dc3545" : "#6c757d") + ";");
+        TaskStyleUtils.fontNormal(attemptLabel, 11);
+        textBox.getChildren().add(attemptLabel);
 
         row.getChildren().addAll(check, textBox);
         return row;
     }
 
+    private String formatAttemptSummary(StudyGoal goal) {
+        String summary = "Attempt " + goal.getAttemptNumber();
+        if (goal.isAchieved()) {
+            summary += " - achieved";
+        } else if (goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.MISSED) {
+            summary += " - missed";
+        } else {
+            summary += " - pending";
+        }
+        return summary;
+    }
+
     /**
-     * Builds a collapsible "Completed" section for achieved goals.
+     * Builds a collapsible "Completed Attempts" section for achieved attempts.
      * Clicking the header toggles visibility of the completed goal rows.
      */
     private VBox buildCompletedGoalsSection(List<StudyGoal> completedGoals) {
@@ -777,7 +913,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         itemsBox.setVisible(false);
         itemsBox.setManaged(false);
 
-        Label toggle = new Label("Completed (" + completedGoals.size() + ")");
+        Label toggle = new Label("Completed Attempts (" + completedGoals.size() + ")");
         toggle.setGraphic(TaskStyleUtils.iconLabel("\u25B6", 11));
         TaskStyleUtils.fontBold(toggle, 11);
         toggle.setTextFill(Color.web("#27ae60"));
@@ -809,15 +945,10 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
 
             VBox textBox = new VBox(2);
             textBox.getChildren().add(label);
-            if (goal.getMissedAttemptCount() > 0) {
-                Label attempts = new Label(String.format("Achieved on attempt %d after %d miss%s",
-                        goal.getAttemptNumber(),
-                        goal.getMissedAttemptCount(),
-                        goal.getMissedAttemptCount() == 1 ? "" : "es"));
-                attempts.setTextFill(Color.web("#7f8c8d"));
-                TaskStyleUtils.fontNormal(attempts, 10);
-                textBox.getChildren().add(attempts);
-            }
+            Label attempts = new Label(formatAttemptSummary(goal));
+            attempts.setTextFill(Color.web("#7f8c8d"));
+            TaskStyleUtils.fontNormal(attempts, 10);
+            textBox.getChildren().add(attempts);
 
             row.getChildren().addAll(check, textBox);
             itemsBox.getChildren().add(row);
@@ -1203,8 +1334,8 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         content.setMaxHeight(Region.USE_PREF_SIZE);
 
         Label headerLabel = new Label(linkedTask != null
-                ? "Add goal for: " + linkedTask.getTitle()
-                : "Create a new study goal");
+                ? "Add goal attempt for: " + linkedTask.getTitle()
+                : "Create a new study goal attempt");
         TaskStyleUtils.fontBold(headerLabel, 16);
 
         // Date
@@ -1224,7 +1355,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         dateRow.setAlignment(Pos.CENTER_LEFT);
 
         TextArea descArea = new TextArea();
-        descArea.setPromptText("Goal description…");
+        descArea.setPromptText("Goal attempt description...");
         descArea.setPrefRowCount(3);
         descArea.setWrapText(true);
 
@@ -1260,7 +1391,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
                     new Label("Description:"), descArea);
         }
 
-        Button okBtn = new Button("Add Goal");
+        Button okBtn = new Button("Add Goal Attempt");
         okBtn.getStyleClass().add("btn-purple");
         okBtn.setDisable(true);
         descArea.textProperty().addListener((obs, o, n) -> okBtn.setDisable(n.trim().isEmpty()));

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -80,6 +80,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     private VBox tasksContainer;
     private FlowPane attemptOverviewContainer;
     private Label taskSectionTitle;
+    private List<StudyGoal> displayDateAttempts = List.of();
+    private Map<String, List<StudyGoal>> displayDateAttemptsByTaskId = Map.of();
+    private Set<String> taskIdsWithAttemptsOnDisplayDate = Set.of();
     private FlowPane sessionsFlowPane;
     private TextArea reflectionArea;
     private ProgressBar dailyProgressBar;
@@ -364,6 +367,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
                     ? "Today's Tasks & Goal Attempts" : "All Active Tasks");
         }
 
+        refreshDisplayDateAttemptCache();
         List<Task> tasks = new ArrayList<>(tasksForCurrentView());
         LocalDate today = dateTimeService.getCurrentDate();
         boolean dateScopedView = currentTaskView == PlannerTaskView.TODAY;
@@ -482,7 +486,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         }
         attemptOverviewContainer.getChildren().clear();
 
-        List<StudyGoal> attempts = getAllAttemptsForDisplayDate();
+        List<StudyGoal> attempts = displayDateAttempts;
         long pending = attempts.stream()
                 .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING)
                 .count();
@@ -532,6 +536,17 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             return studyService.getAllGoalsForFutureDate(displayDate);
         }
         return studyService.getAllGoalsForDate(displayDate);
+    }
+
+    private void refreshDisplayDateAttemptCache() {
+        displayDateAttempts = getAllAttemptsForDisplayDate();
+        displayDateAttemptsByTaskId = displayDateAttempts.stream()
+                .filter(goal -> goal.getTaskId() != null && !goal.getTaskId().isBlank())
+                .collect(Collectors.groupingBy(
+                        StudyGoal::getTaskId,
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+        taskIdsWithAttemptsOnDisplayDate = new HashSet<>(displayDateAttemptsByTaskId.keySet());
     }
 
     private List<Task> tasksForCurrentView() {
@@ -585,10 +600,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     }
 
     private boolean hasGoalOnDisplayDate(Task task) {
-        return task != null
-                && StudyGoal.findByTaskIdForDate(task.getId(), displayDate).stream()
-                        .findAny()
-                        .isPresent();
+        return task != null && taskIdsWithAttemptsOnDisplayDate.contains(task.getId());
     }
 
     /** Returns a comparator based on the user's current sort choice. */
@@ -741,9 +753,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
     }
 
     private List<Label> createTaskAttemptBadges(Task task) {
-        List<StudyGoal> attempts = StudyGoal.findByTaskId(task.getId()).stream()
-                .filter(goal -> displayDate.equals(goal.getDate()))
-                .toList();
+        List<StudyGoal> attempts = displayDateAttemptsByTaskId.getOrDefault(task.getId(), List.of());
         if (attempts.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -548,7 +548,9 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         if (desc != null && desc.length() > 60) {
             desc = desc.substring(0, 57) + "...";
         }
-        return taskLabel + desc + " (" + goal.getDaysDelayed() + "d delayed)";
+        int misses = goal.getMissedAttemptCount();
+        String missLabel = misses == 1 ? "1 prior miss" : misses + " prior misses";
+        return taskLabel + desc + " (attempt " + (goal.getAttemptNumber() + 1) + ", " + missLabel + ")";
     }
 
     /**
@@ -750,8 +752,10 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         textBox.getChildren().add(goalLabel);
 
         if (goal.isDelayed()) {
-            Label delayLabel = new Label(String.format("Delayed %d day(s) — -%d pts",
-                    goal.getDaysDelayed(), goal.getPointsDeducted()));
+            Label delayLabel = new Label(String.format("Attempt %d (%d prior miss%s)",
+                    goal.getAttemptNumber(),
+                    goal.getMissedAttemptCount(),
+                    goal.getMissedAttemptCount() == 1 ? "" : "es"));
             delayLabel.setStyle("-fx-text-fill: #dc3545;");
             TaskStyleUtils.fontNormal(delayLabel, 11);
             textBox.getChildren().add(delayLabel);
@@ -803,7 +807,19 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
             label.setStyle("-fx-strikethrough: true; -fx-text-fill: #7f8c8d;");
             TaskStyleUtils.fontNormal(label, 12);
 
-            row.getChildren().addAll(check, label);
+            VBox textBox = new VBox(2);
+            textBox.getChildren().add(label);
+            if (goal.getMissedAttemptCount() > 0) {
+                Label attempts = new Label(String.format("Achieved on attempt %d after %d miss%s",
+                        goal.getAttemptNumber(),
+                        goal.getMissedAttemptCount(),
+                        goal.getMissedAttemptCount() == 1 ? "" : "es"));
+                attempts.setTextFill(Color.web("#7f8c8d"));
+                TaskStyleUtils.fontNormal(attempts, 10);
+                textBox.getChildren().add(attempts);
+            }
+
+            row.getChildren().addAll(check, textBox);
             itemsBox.getChildren().add(row);
         }
 

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -391,108 +391,186 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
     private void populateGoalHistory(VBox pane, Task task) {
         pane.getChildren().clear();
 
-        List<StudyGoal> goals = StudyGoal.findByTaskId(task.getId());
+        List<StudyGoal> attempts = StudyGoal.findByTaskId(task.getId());
 
-        if (goals.isEmpty()) {
-            Label empty = new Label("No goals have been planned for this task yet.");
+        if (attempts.isEmpty()) {
+            Label empty = new Label("No attempts have been planned for this task yet.");
             TaskStyleUtils.fontNormal(empty, 12);
             empty.setTextFill(Color.web("#7f8c8d"));
             pane.getChildren().add(empty);
             return;
         }
 
-        // Summary stats
-        long achieved = goals.stream().filter(StudyGoal::isAchieved).count();
-        long missed = goals.stream().filter(StudyGoal::isFailed).count();
-        long active = goals.stream().filter(g -> !g.isAchieved() && !g.isFailed()).count();
+        Map<String, List<StudyGoal>> attemptsByGoal = attempts.stream()
+                .collect(Collectors.groupingBy(StudyGoal::getId, LinkedHashMap::new, Collectors.toList()));
+        attemptsByGoal.values().forEach(goalAttempts ->
+                goalAttempts.sort(Comparator.comparingInt(StudyGoal::getAttemptNumber)));
 
-        Label statsLabel = new Label("Total: " + goals.size()
+        long achieved = attempts.stream().filter(StudyGoal::isAchieved).count();
+        long missed = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.MISSED)
+                .count();
+        long active = attempts.stream()
+                .filter(goal -> goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING
+                        && goal.getStatus() == StudyGoal.GoalStatus.ACTIVE)
+                .count();
+        int score = (int) (achieved - missed);
+
+        Label statsLabel = new Label("Goals: " + attemptsByGoal.size()
+                + "  |  Attempts: " + attempts.size()
                 + "  |  Achieved: " + achieved
                 + "  |  Missed: " + missed
-                + "  |  Active: " + active);
+                + "  |  Active: " + active
+                + "  |  Score: " + String.format("%+d", score));
         TaskStyleUtils.fontSemiBold(statsLabel, 11);
         statsLabel.setTextFill(Color.web("#495057"));
         statsLabel.setPadding(new Insets(0, 0, 4, 0));
         pane.getChildren().add(statsLabel);
 
-        // Goal list
-        for (StudyGoal goal : goals) {
-            HBox row = new HBox(8);
-            row.setAlignment(Pos.CENTER_LEFT);
-            row.setPadding(new Insets(4, 8, 4, 8));
-
-            // Status indicator
-            String statusIcon;
-            String statusColor;
-            if (goal.isAchieved()) {
-                statusIcon = "\u2713"; // checkmark
-                statusColor = "#27ae60";
-            } else if (goal.isFailed()) {
-                statusIcon = "\u2715"; // X
-                statusColor = "#e74c3c";
-            } else if (goal.isDelayed()) {
-                statusIcon = "\u231B"; // hourglass
-                statusColor = "#f39c12";
-            } else {
-                statusIcon = "\u25CB"; // circle
-                statusColor = "#3498db";
-            }
-
-            Label icon = TaskStyleUtils.iconLabel(statusIcon, 11);
-            icon.setTextFill(Color.web(statusColor));
-
-            // Date
-            Label dateLabel = new Label(goal.getDate().toString());
-            TaskStyleUtils.fontNormal(dateLabel, 11);
-            dateLabel.setTextFill(Color.web("#6c757d"));
-            dateLabel.setMinWidth(80);
-
-            // Description
-            String descText = goal.getDescription() != null ? goal.getDescription() : "";
-            if (descText.length() > 80) descText = descText.substring(0, 80) + "...";
-            Label descLabel = new Label(descText);
-            TaskStyleUtils.fontNormal(descLabel, 11);
-            descLabel.setWrapText(true);
-            HBox.setHgrow(descLabel, Priority.ALWAYS);
-            if (goal.isFailed()) {
-                descLabel.setTextFill(Color.web("#999"));
-            } else if (goal.isAchieved()) {
-                descLabel.setTextFill(Color.web("#2d6a4f"));
-            } else {
-                descLabel.setTextFill(Color.web("#333"));
-            }
-
-            // Status badge
-            Label badge;
-            if (goal.isAchieved()) {
-                badge = new Label("Achieved");
-                badge.setStyle("-fx-background-color: #e8f5e9; -fx-background-radius: 8; -fx-padding: 1 6;");
-                badge.setTextFill(Color.web("#1b5e20"));
-            } else if (goal.isFailed()) {
-                badge = new Label(goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned" : "Missed");
-                badge.setStyle("-fx-background-color: #ffebee; -fx-background-radius: 8; -fx-padding: 1 6;");
-                badge.setTextFill(Color.web("#b71c1c"));
-            } else if (goal.isDelayed()) {
-                badge = new Label("Attempt " + goal.getAttemptNumber()
-                        + " (" + goal.getMissedAttemptCount() + " miss"
-                        + (goal.getMissedAttemptCount() == 1 ? "" : "es") + ")");
-                badge.setStyle("-fx-background-color: #fff3e0; -fx-background-radius: 8; -fx-padding: 1 6;");
-                badge.setTextFill(Color.web("#e65100"));
-            } else {
-                badge = new Label("Active");
-                badge.setStyle("-fx-background-color: #e3f2fd; -fx-background-radius: 8; -fx-padding: 1 6;");
-                badge.setTextFill(Color.web("#0d47a1"));
-            }
-            TaskStyleUtils.fontBold(badge, 10);
-
-            row.getChildren().addAll(icon, dateLabel, descLabel, badge);
-
-            // Alternate row background
-            row.setStyle("-fx-background-color: " + (pane.getChildren().size() % 2 == 0 ? "#f0f0f0" : "transparent") +
-                         "; -fx-background-radius: 4;");
-
-            pane.getChildren().add(row);
+        for (List<StudyGoal> goalAttempts : attemptsByGoal.values()) {
+            pane.getChildren().add(createGoalAttemptTimeline(goalAttempts));
         }
+    }
+
+    private VBox createGoalAttemptTimeline(List<StudyGoal> attempts) {
+        StudyGoal latest = attempts.get(attempts.size() - 1);
+
+        VBox card = new VBox(8);
+        card.setPadding(new Insets(10));
+        card.setStyle("-fx-background-color: white; -fx-background-radius: 6; -fx-border-color: #dee2e6;"
+                + " -fx-border-radius: 6;");
+
+        HBox header = new HBox(8);
+        header.setAlignment(Pos.CENTER_LEFT);
+
+        Label title = new Label(shorten(latest.getDescription(), 90));
+        TaskStyleUtils.fontSemiBold(title, 12);
+        title.setTextFill(Color.web("#2c3e50"));
+        title.setWrapText(true);
+        HBox.setHgrow(title, Priority.ALWAYS);
+
+        Label parentBadge = new Label(parentStatusLabel(latest));
+        TaskStyleUtils.fontBold(parentBadge, 10);
+        parentBadge.setTextFill(Color.web(parentStatusColor(latest)));
+        parentBadge.setStyle("-fx-background-color: " + parentStatusBackground(latest)
+                + "; -fx-background-radius: 8; -fx-padding: 2 8;");
+
+        header.getChildren().addAll(title, parentBadge);
+
+        Label summary = new Label("Latest attempt " + latest.getAttemptNumber()
+                + " | " + attempts.size() + " total attempt" + (attempts.size() == 1 ? "" : "s"));
+        TaskStyleUtils.fontNormal(summary, 11);
+        summary.setTextFill(Color.web("#6c757d"));
+
+        VBox timeline = new VBox(4);
+        for (StudyGoal attempt : attempts) {
+            timeline.getChildren().add(createAttemptTimelineRow(attempt));
+        }
+
+        card.getChildren().addAll(header, summary, timeline);
+        return card;
+    }
+
+    private HBox createAttemptTimelineRow(StudyGoal attempt) {
+        HBox row = new HBox(8);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.setPadding(new Insets(4, 6, 4, 6));
+        row.setStyle("-fx-background-color: #f8f9fa; -fx-background-radius: 4;");
+
+        Label marker = TaskStyleUtils.iconLabel(attemptIcon(attempt), 11);
+        marker.setTextFill(Color.web(attemptStatusColor(attempt)));
+
+        Label attemptLabel = new Label("Attempt " + attempt.getAttemptNumber());
+        TaskStyleUtils.fontSemiBold(attemptLabel, 11);
+        attemptLabel.setMinWidth(72);
+        attemptLabel.setTextFill(Color.web("#495057"));
+
+        Label dateLabel = new Label(attempt.getDate().toString());
+        TaskStyleUtils.fontNormal(dateLabel, 11);
+        dateLabel.setMinWidth(82);
+        dateLabel.setTextFill(Color.web("#6c757d"));
+
+        Label status = new Label(attemptStatusLabel(attempt));
+        TaskStyleUtils.fontBold(status, 10);
+        status.setTextFill(Color.web(attemptStatusColor(attempt)));
+        status.setStyle("-fx-background-color: " + attemptStatusBackground(attempt)
+                + "; -fx-background-radius: 8; -fx-padding: 1 7;");
+
+        row.getChildren().addAll(marker, attemptLabel, dateLabel, status);
+        return row;
+    }
+
+    private String parentStatusLabel(StudyGoal goal) {
+        if (goal.getStatus() == StudyGoal.GoalStatus.ACHIEVED) {
+            return "Achieved";
+        }
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
+            return "Abandoned";
+        }
+        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING ? "Active" : "Needs retry";
+    }
+
+    private String parentStatusColor(StudyGoal goal) {
+        if (goal.getStatus() == StudyGoal.GoalStatus.ACHIEVED) {
+            return "#1b5e20";
+        }
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
+            return "#7f1d1d";
+        }
+        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING ? "#0d47a1" : "#e65100";
+    }
+
+    private String parentStatusBackground(StudyGoal goal) {
+        if (goal.getStatus() == StudyGoal.GoalStatus.ACHIEVED) {
+            return "#e8f5e9";
+        }
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
+            return "#ffebee";
+        }
+        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING ? "#e3f2fd" : "#fff3e0";
+    }
+
+    private String attemptIcon(StudyGoal attempt) {
+        return switch (attempt.getAttemptOutcome()) {
+            case ACHIEVED -> "\u2713";
+            case MISSED -> "\u2715";
+            case PENDING -> "\u25CB";
+        };
+    }
+
+    private String attemptStatusLabel(StudyGoal attempt) {
+        if (attempt.getStatus() == StudyGoal.GoalStatus.ABANDONED
+                && attempt.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING) {
+            return "Abandoned";
+        }
+        return switch (attempt.getAttemptOutcome()) {
+            case ACHIEVED -> "Achieved";
+            case MISSED -> "Missed";
+            case PENDING -> "Pending";
+        };
+    }
+
+    private String attemptStatusColor(StudyGoal attempt) {
+        return switch (attempt.getAttemptOutcome()) {
+            case ACHIEVED -> "#1b5e20";
+            case MISSED -> "#b71c1c";
+            case PENDING -> "#0d47a1";
+        };
+    }
+
+    private String attemptStatusBackground(StudyGoal attempt) {
+        return switch (attempt.getAttemptOutcome()) {
+            case ACHIEVED -> "#e8f5e9";
+            case MISSED -> "#ffebee";
+            case PENDING -> "#e3f2fd";
+        };
+    }
+
+    private String shorten(String text, int maxLength) {
+        if (text == null) {
+            return "";
+        }
+        return text.length() > maxLength ? text.substring(0, maxLength - 3) + "..." : text;
     }
 
     // ──────────────────────────────────────────────

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -507,8 +507,24 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         for (StudyGoal attempt : attempts) {
             timeline.getChildren().add(createAttemptTimelineRow(attempt));
         }
+        timeline.setVisible(false);
+        timeline.setManaged(false);
 
-        card.getChildren().addAll(header, summary, timeline);
+        Button toggleAttemptsBtn = new Button("Show attempts");
+        toggleAttemptsBtn.getStyleClass().addAll("btn-gray", "btn-small");
+        toggleAttemptsBtn.setOnAction(e -> {
+            boolean show = !timeline.isManaged();
+            timeline.setVisible(show);
+            timeline.setManaged(show);
+            toggleAttemptsBtn.setText(show ? "Hide attempts" : "Show attempts");
+        });
+
+        Region summarySpacer = new Region();
+        HBox.setHgrow(summarySpacer, Priority.ALWAYS);
+        HBox summaryRow = new HBox(8, summary, summarySpacer, toggleAttemptsBtn);
+        summaryRow.setAlignment(Pos.CENTER_LEFT);
+
+        card.getChildren().addAll(header, summaryRow, timeline);
         return card;
     }
 

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -403,12 +403,12 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
         // Summary stats
         long achieved = goals.stream().filter(StudyGoal::isAchieved).count();
-        long failed = goals.stream().filter(StudyGoal::isFailed).count();
+        long missed = goals.stream().filter(StudyGoal::isFailed).count();
         long active = goals.stream().filter(g -> !g.isAchieved() && !g.isFailed()).count();
 
         Label statsLabel = new Label("Total: " + goals.size()
                 + "  |  Achieved: " + achieved
-                + "  |  Failed: " + failed
+                + "  |  Missed: " + missed
                 + "  |  Active: " + active);
         TaskStyleUtils.fontSemiBold(statsLabel, 11);
         statsLabel.setTextFill(Color.web("#495057"));
@@ -469,11 +469,13 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
                 badge.setStyle("-fx-background-color: #e8f5e9; -fx-background-radius: 8; -fx-padding: 1 6;");
                 badge.setTextFill(Color.web("#1b5e20"));
             } else if (goal.isFailed()) {
-                badge = new Label("Failed");
+                badge = new Label(goal.getStatus() == StudyGoal.GoalStatus.ABANDONED ? "Abandoned" : "Missed");
                 badge.setStyle("-fx-background-color: #ffebee; -fx-background-radius: 8; -fx-padding: 1 6;");
                 badge.setTextFill(Color.web("#b71c1c"));
             } else if (goal.isDelayed()) {
-                badge = new Label("Delayed (" + goal.getDaysDelayed() + "d)");
+                badge = new Label("Attempt " + goal.getAttemptNumber()
+                        + " (" + goal.getMissedAttemptCount() + " miss"
+                        + (goal.getMissedAttemptCount() == 1 ? "" : "es") + ")");
                 badge.setStyle("-fx-background-color: #fff3e0; -fx-background-radius: 8; -fx-padding: 1 6;");
                 badge.setTextFill(Color.web("#e65100"));
             } else {

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -366,8 +366,9 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
         Button goalHistoryBtn = new Button("Goal History");
         goalHistoryBtn.getStyleClass().addAll("btn-small");
-        goalHistoryBtn.setStyle("-fx-font-size: 11px; -fx-padding: 3 10; -fx-background-color: #e8eaf6;" +
-                                " -fx-background-radius: 4; -fx-text-fill: #3949ab; -fx-cursor: hand;");
+        goalHistoryBtn.setStyle("-fx-font-size: 11px; -fx-padding: 3 10; -fx-background-color: "
+                + TaskStyleUtils.TINT_PRIMARY + "; -fx-background-radius: 4; -fx-text-fill: "
+                + TaskStyleUtils.COLOR_PRIMARY + "; -fx-cursor: hand;");
         goalHistoryBtn.setOnAction(e -> {
             boolean showing = goalHistoryPane.isVisible();
             if (!showing) {
@@ -399,7 +400,7 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
         Label heading = new Label("Goal history");
         TaskStyleUtils.fontBold(heading, 12);
-        heading.setTextFill(Color.web("#3949ab"));
+        heading.setTextFill(Color.web(TaskStyleUtils.COLOR_PRIMARY));
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
@@ -435,20 +436,25 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
                 .count();
         int score = (int) (achieved - missed);
 
-        Label statsLabel = new Label("Goals: " + attemptsByGoal.size()
-                + "  |  Attempts: " + attempts.size()
-                + "  |  Achieved: " + achieved
-                + "  |  Missed: " + missed
-                + "  |  Active: " + active
-                + "  |  Score: " + String.format("%+d", score));
-        TaskStyleUtils.fontSemiBold(statsLabel, 11);
-        statsLabel.setTextFill(Color.web("#495057"));
-        statsLabel.setPadding(new Insets(0, 0, 4, 0));
-        pane.getChildren().add(statsLabel);
+        FlowPane stats = new FlowPane(6, 4);
+        stats.setPadding(new Insets(0, 0, 4, 0));
+        stats.getChildren().addAll(
+                createStatChip("Goals " + attemptsByGoal.size(), TaskStyleUtils.COLOR_PRIMARY),
+                createStatChip("Attempts " + attempts.size(), TaskStyleUtils.COLOR_PRIMARY),
+                createStatChip("Done " + achieved, TaskStyleUtils.COLOR_SUCCESS),
+                createStatChip("Missed " + missed, TaskStyleUtils.COLOR_DANGER),
+                createStatChip("Active " + active, TaskStyleUtils.COLOR_PRIMARY),
+                createStatChip("Lifetime net " + String.format("%+d", score), TaskStyleUtils.COLOR_PURPLE)
+        );
+        pane.getChildren().add(stats);
 
         for (List<StudyGoal> goalAttempts : attemptsByGoal.values()) {
             pane.getChildren().add(createGoalAttemptTimeline(task, goalAttempts, pane));
         }
+    }
+
+    private Label createStatChip(String text, String textColor) {
+        return TaskStyleUtils.createAttemptBadge(text, textColor, TaskStyleUtils.TINT_NEUTRAL);
     }
 
     private VBox createGoalAttemptTimeline(Task task, List<StudyGoal> attempts, VBox ownerPane) {
@@ -542,7 +548,9 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         HBox row = new HBox(8);
         row.setAlignment(Pos.CENTER_LEFT);
         row.setPadding(new Insets(4, 6, 4, 6));
-        row.setStyle("-fx-background-color: #f8f9fa; -fx-background-radius: 4;");
+        row.setStyle("-fx-background-color: " + TaskStyleUtils.TINT_NEUTRAL + "; -fx-background-radius: 4;"
+                + " -fx-border-color: transparent transparent transparent " + attemptStatusColor(attempt) + ";"
+                + " -fx-border-width: 0 0 0 4; -fx-border-radius: 4;");
 
         Label marker = TaskStyleUtils.iconLabel(attemptIcon(attempt), 11);
         marker.setTextFill(Color.web(attemptStatusColor(attempt)));
@@ -579,22 +587,24 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
     private String parentStatusColor(StudyGoal goal) {
         if (goal.getStatus() == StudyGoal.GoalStatus.ACHIEVED) {
-            return "#1b5e20";
+            return TaskStyleUtils.COLOR_SUCCESS;
         }
         if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
-            return "#7f1d1d";
+            return TaskStyleUtils.COLOR_DANGER;
         }
-        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING ? "#0d47a1" : "#e65100";
+        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING
+                ? TaskStyleUtils.COLOR_PRIMARY : TaskStyleUtils.retryTextColor();
     }
 
     private String parentStatusBackground(StudyGoal goal) {
         if (goal.getStatus() == StudyGoal.GoalStatus.ACHIEVED) {
-            return "#e8f5e9";
+            return TaskStyleUtils.TINT_SUCCESS;
         }
         if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
-            return "#ffebee";
+            return TaskStyleUtils.TINT_DANGER;
         }
-        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING ? "#e3f2fd" : "#fff3e0";
+        return goal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING
+                ? TaskStyleUtils.TINT_PRIMARY : TaskStyleUtils.retryBackgroundColor();
     }
 
     private String attemptIcon(StudyGoal attempt) {
@@ -618,19 +628,11 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
     }
 
     private String attemptStatusColor(StudyGoal attempt) {
-        return switch (attempt.getAttemptOutcome()) {
-            case ACHIEVED -> "#1b5e20";
-            case MISSED -> "#b71c1c";
-            case PENDING -> "#0d47a1";
-        };
+        return TaskStyleUtils.attemptTextColor(attempt);
     }
 
     private String attemptStatusBackground(StudyGoal attempt) {
-        return switch (attempt.getAttemptOutcome()) {
-            case ACHIEVED -> "#e8f5e9";
-            case MISSED -> "#ffebee";
-            case PENDING -> "#e3f2fd";
-        };
+        return TaskStyleUtils.attemptBackgroundColor(attempt);
     }
 
     private String shorten(String text, int maxLength) {
@@ -723,7 +725,7 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         form.setMaxWidth(460);
         form.setMaxHeight(Region.USE_PREF_SIZE);
 
-        Label title = new Label("Plan Goal Attempt");
+        Label title = new Label("Plan Goal");
         TaskStyleUtils.fontBold(title, 18);
 
         Label description = new Label(goal.getDescription());
@@ -733,7 +735,7 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         DatePicker datePicker = new DatePicker(LocalDate.now());
         datePicker.setMaxWidth(Double.MAX_VALUE);
 
-        Button planBtn = new Button("Plan Attempt");
+        Button planBtn = new Button("Plan Goal");
         planBtn.getStyleClass().add("btn-orange");
         Button cancelBtn = new Button("Cancel");
         cancelBtn.getStyleClass().add("btn-cancel");
@@ -762,7 +764,7 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         buttons.setAlignment(Pos.CENTER_RIGHT);
 
         form.getChildren().addAll(title, new Label("Goal:"), description,
-                new Label("Attempt date:"), datePicker, buttons);
+                new Label("Date:"), datePicker, buttons);
         showModal.accept(wrapGoalModal(form));
     }
 

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -10,6 +10,7 @@ import com.studysync.domain.valueobject.TaskStatus;
 import com.studysync.domain.service.TaskService;
 import com.studysync.domain.service.CategoryService;
 import com.studysync.domain.service.ReminderService;
+import com.studysync.domain.service.StudyService;
 import com.studysync.domain.service.TaskUpdate;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -34,6 +35,7 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
     private final TaskService taskService;
     private final CategoryService categoryService;
     private final ReminderService reminderService;
+    private final StudyService studyService;
     private final Consumer<Node> showModal;
     private final Runnable closeModal;
 
@@ -47,11 +49,12 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
     private TabPane statusTabPane;
 
     public TaskManagementPanel(TaskService taskService, CategoryService categoryService,
-                               ReminderService reminderService,
+                               ReminderService reminderService, StudyService studyService,
                                Consumer<Node> showModal, Runnable closeModal) {
         this.taskService = taskService;
         this.categoryService = categoryService;
         this.reminderService = reminderService;
+        this.studyService = studyService;
         this.showModal = showModal;
         this.closeModal = closeModal;
 
@@ -391,6 +394,22 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
     private void populateGoalHistory(VBox pane, Task task) {
         pane.getChildren().clear();
 
+        HBox toolbar = new HBox(8);
+        toolbar.setAlignment(Pos.CENTER_LEFT);
+
+        Label heading = new Label("Goal history");
+        TaskStyleUtils.fontBold(heading, 12);
+        heading.setTextFill(Color.web("#3949ab"));
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        Button addGoalBtn = new Button("+ Plan Goal");
+        addGoalBtn.getStyleClass().addAll("btn-purple", "btn-small");
+        addGoalBtn.setOnAction(e -> showTaskGoalForm(task, null, pane));
+        toolbar.getChildren().addAll(heading, spacer, addGoalBtn);
+        pane.getChildren().add(toolbar);
+
         List<StudyGoal> attempts = StudyGoal.findByTaskId(task.getId());
 
         if (attempts.isEmpty()) {
@@ -428,11 +447,11 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         pane.getChildren().add(statsLabel);
 
         for (List<StudyGoal> goalAttempts : attemptsByGoal.values()) {
-            pane.getChildren().add(createGoalAttemptTimeline(goalAttempts));
+            pane.getChildren().add(createGoalAttemptTimeline(task, goalAttempts, pane));
         }
     }
 
-    private VBox createGoalAttemptTimeline(List<StudyGoal> attempts) {
+    private VBox createGoalAttemptTimeline(Task task, List<StudyGoal> attempts, VBox ownerPane) {
         StudyGoal latest = attempts.get(attempts.size() - 1);
 
         VBox card = new VBox(8);
@@ -455,7 +474,29 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         parentBadge.setStyle("-fx-background-color: " + parentStatusBackground(latest)
                 + "; -fx-background-radius: 8; -fx-padding: 2 8;");
 
-        header.getChildren().addAll(title, parentBadge);
+        HBox actions = new HBox(6);
+        actions.setAlignment(Pos.CENTER_RIGHT);
+
+        Button editBtn = new Button("Edit");
+        editBtn.getStyleClass().addAll("btn-primary", "btn-small");
+        editBtn.setOnAction(e -> showTaskGoalForm(task, latest, ownerPane));
+        actions.getChildren().add(editBtn);
+
+        if (canPlanAnotherAttempt(latest)) {
+            Button planBtn = new Button("Plan");
+            planBtn.getStyleClass().addAll("btn-orange", "btn-small");
+            planBtn.setOnAction(e -> showPlanGoalAttemptForm(task, latest, ownerPane));
+            actions.getChildren().add(planBtn);
+        }
+
+        if (canAbandonGoal(latest)) {
+            Button abandonBtn = new Button("Abandon");
+            abandonBtn.getStyleClass().addAll("btn-danger", "btn-small");
+            abandonBtn.setOnAction(e -> confirmAbandonGoal(task, latest, ownerPane));
+            actions.getChildren().add(abandonBtn);
+        }
+
+        header.getChildren().addAll(title, parentBadge, actions);
 
         Label summary = new Label("Latest attempt " + latest.getAttemptNumber()
                 + " | " + attempts.size() + " total attempt" + (attempts.size() == 1 ? "" : "s"));
@@ -469,6 +510,16 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
         card.getChildren().addAll(header, summary, timeline);
         return card;
+    }
+
+    private boolean canPlanAnotherAttempt(StudyGoal goal) {
+        return goal.getStatus() == StudyGoal.GoalStatus.ACTIVE
+                && goal.getAttemptOutcome() != StudyGoal.AttemptOutcome.PENDING
+                && !goal.isAchieved();
+    }
+
+    private boolean canAbandonGoal(StudyGoal goal) {
+        return goal.getStatus() == StudyGoal.GoalStatus.ACTIVE && !goal.isAchieved();
     }
 
     private HBox createAttemptTimelineRow(StudyGoal attempt) {
@@ -571,6 +622,155 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
             return "";
         }
         return text.length() > maxLength ? text.substring(0, maxLength - 3) + "..." : text;
+    }
+
+    private void showTaskGoalForm(Task task, StudyGoal existingGoal, VBox ownerPane) {
+        boolean isNew = existingGoal == null;
+
+        VBox form = new VBox(12);
+        form.setPadding(new Insets(24));
+        form.getStyleClass().add("modal-content-light");
+        form.setMaxWidth(500);
+        form.setMaxHeight(Region.USE_PREF_SIZE);
+
+        Label title = new Label(isNew ? "Plan Goal for Task" : "Edit Goal");
+        TaskStyleUtils.fontBold(title, 18);
+
+        Label taskLabel = new Label(task.getTitle());
+        TaskStyleUtils.fontSemiBold(taskLabel, 12);
+        taskLabel.setTextFill(Color.web("#495057"));
+        taskLabel.setWrapText(true);
+
+        TextArea descriptionArea = new TextArea(isNew ? "" : nvl(existingGoal.getDescription()));
+        descriptionArea.setPromptText("Goal description");
+        descriptionArea.setPrefRowCount(3);
+        descriptionArea.setWrapText(true);
+
+        boolean canEditDate = isNew || existingGoal.getAttemptOutcome() == StudyGoal.AttemptOutcome.PENDING;
+        DatePicker datePicker = new DatePicker(isNew ? LocalDate.now() : existingGoal.getDate());
+        datePicker.setMaxWidth(Double.MAX_VALUE);
+        datePicker.setDisable(!canEditDate);
+
+        Label dateHint = new Label(canEditDate
+                ? "Choose when this attempt should appear in the planner."
+                : "Only pending attempts can be rescheduled. Use Plan to create a new dated attempt.");
+        TaskStyleUtils.fontNormal(dateHint, 11);
+        dateHint.setTextFill(Color.web("#6c757d"));
+        dateHint.setWrapText(true);
+
+        Button saveBtn = new Button(isNew ? "Plan Goal" : "Save Goal");
+        saveBtn.getStyleClass().add("btn-primary");
+        Button cancelBtn = new Button("Cancel");
+        cancelBtn.getStyleClass().add("btn-cancel");
+        cancelBtn.setOnAction(e -> closeModal.run());
+
+        saveBtn.setOnAction(e -> {
+            String description = descriptionArea.getText().trim();
+            LocalDate plannedDate = datePicker.getValue();
+            if (description.isEmpty()) {
+                showInlineError(form, "Description is required.");
+                return;
+            }
+            if (canEditDate && plannedDate == null) {
+                showInlineError(form, "Planned date is required.");
+                return;
+            }
+
+            try {
+                if (isNew) {
+                    studyService.addStudyGoal(description, plannedDate, task.getId());
+                } else {
+                    studyService.updateStudyGoalDetails(existingGoal.getId(), description,
+                            canEditDate ? plannedDate : null);
+                }
+                closeModal.run();
+                populateGoalHistory(ownerPane, task);
+            } catch (Exception ex) {
+                showInlineError(form, ex.getMessage());
+            }
+        });
+
+        HBox buttons = new HBox(10, saveBtn, cancelBtn);
+        buttons.setAlignment(Pos.CENTER_RIGHT);
+
+        form.getChildren().addAll(title, new Label("Task:"), taskLabel,
+                new Label("Description:"), descriptionArea,
+                new Label("Planned date:"), datePicker, dateHint, buttons);
+
+        showModal.accept(wrapGoalModal(form));
+    }
+
+    private void showPlanGoalAttemptForm(Task task, StudyGoal goal, VBox ownerPane) {
+        VBox form = new VBox(12);
+        form.setPadding(new Insets(24));
+        form.getStyleClass().add("modal-content-light");
+        form.setMaxWidth(460);
+        form.setMaxHeight(Region.USE_PREF_SIZE);
+
+        Label title = new Label("Plan Goal Attempt");
+        TaskStyleUtils.fontBold(title, 18);
+
+        Label description = new Label(goal.getDescription());
+        TaskStyleUtils.fontNormal(description, 13);
+        description.setWrapText(true);
+
+        DatePicker datePicker = new DatePicker(LocalDate.now());
+        datePicker.setMaxWidth(Double.MAX_VALUE);
+
+        Button planBtn = new Button("Plan Attempt");
+        planBtn.getStyleClass().add("btn-orange");
+        Button cancelBtn = new Button("Cancel");
+        cancelBtn.getStyleClass().add("btn-cancel");
+        cancelBtn.setOnAction(e -> closeModal.run());
+
+        planBtn.setOnAction(e -> {
+            LocalDate plannedDate = datePicker.getValue();
+            if (plannedDate == null) {
+                showInlineError(form, "Planned date is required.");
+                return;
+            }
+            try {
+                boolean created = studyService.planGoalAttempt(goal.getId(), plannedDate);
+                if (!created) {
+                    showInlineError(form, "This goal already has a pending attempt or cannot be replanned.");
+                    return;
+                }
+                closeModal.run();
+                populateGoalHistory(ownerPane, task);
+            } catch (Exception ex) {
+                showInlineError(form, ex.getMessage());
+            }
+        });
+
+        HBox buttons = new HBox(10, planBtn, cancelBtn);
+        buttons.setAlignment(Pos.CENTER_RIGHT);
+
+        form.getChildren().addAll(title, new Label("Goal:"), description,
+                new Label("Attempt date:"), datePicker, buttons);
+        showModal.accept(wrapGoalModal(form));
+    }
+
+    private void confirmAbandonGoal(Task task, StudyGoal goal, VBox ownerPane) {
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                "Abandon \"" + shorten(goal.getDescription(), 80) + "\"?",
+                ButtonType.OK, ButtonType.CANCEL);
+        confirm.setTitle("Abandon Goal");
+        confirm.setHeaderText(null);
+        confirm.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
+        confirm.showAndWait().ifPresent(button -> {
+            if (button == ButtonType.OK && studyService.markGoalAsFailed(goal.getId())) {
+                populateGoalHistory(ownerPane, task);
+            }
+        });
+    }
+
+    private ScrollPane wrapGoalModal(VBox form) {
+        ScrollPane wrapper = new ScrollPane(form);
+        wrapper.setFitToWidth(true);
+        wrapper.getStyleClass().add("transparent-bg");
+        wrapper.setMaxWidth(520);
+        wrapper.setMaxHeight(560);
+        return wrapper;
     }
 
     // ──────────────────────────────────────────────

--- a/src/main/java/com/studysync/presentation/ui/components/TaskStyleUtils.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskStyleUtils.java
@@ -1,6 +1,7 @@
 package com.studysync.presentation.ui.components;
 
 import com.studysync.domain.entity.Task;
+import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.valueobject.TaskStatus;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
@@ -29,6 +30,21 @@ import java.util.Locale;
 public final class TaskStyleUtils {
 
     private TaskStyleUtils() { /* utility class */ }
+
+    public static final String COLOR_PRIMARY = "#3498db";
+    public static final String COLOR_SUCCESS = "#27ae60";
+    public static final String COLOR_DANGER = "#e74c3c";
+    public static final String COLOR_PURPLE = "#9b59b6";
+    public static final String COLOR_ORANGE = "#e67e22";
+    public static final String COLOR_MUTED = "#7f8c8d";
+    public static final String COLOR_TEXT = "#2c3e50";
+
+    public static final String TINT_PRIMARY = "#e3f2fd";
+    public static final String TINT_SUCCESS = "#e8f5e9";
+    public static final String TINT_DANGER = "#ffebee";
+    public static final String TINT_PURPLE = "#f3e5f5";
+    public static final String TINT_ORANGE = "#fff3e0";
+    public static final String TINT_NEUTRAL = "#f8f9fa";
 
     // ── CSS-safe font helpers ───────────────────────────────────
 
@@ -99,12 +115,12 @@ public final class TaskStyleUtils {
     /** Border colour keyed directly by status. */
     public static String taskBorderColor(TaskStatus s) {
         return switch (s) {
-            case COMPLETED   -> "#27ae60";
-            case DELAYED     -> "#e74c3c";
+            case COMPLETED   -> COLOR_SUCCESS;
+            case DELAYED     -> COLOR_DANGER;
             case IN_PROGRESS -> "#f39c12";
             case CANCELLED   -> "#bdc3c7";
             case POSTPONED   -> "#9c27b0";
-            default          -> "#3498db";
+            default          -> COLOR_PRIMARY;
         };
     }
 
@@ -141,12 +157,12 @@ public final class TaskStyleUtils {
     /** Text colour for status badges — dark shades for readability. */
     public static Color statusTextColor(TaskStatus s) {
         return switch (s) {
-            case COMPLETED   -> Color.web("#1b5e20");
-            case DELAYED     -> Color.web("#b71c1c");
+            case COMPLETED   -> Color.web(COLOR_SUCCESS);
+            case DELAYED     -> Color.web(COLOR_DANGER);
             case IN_PROGRESS -> Color.web("#8a4b00");
             case CANCELLED   -> Color.web("#37474f");
             case POSTPONED   -> Color.web("#5e35b1");
-            default          -> Color.web("#0d47a1");
+            default          -> Color.web(COLOR_PRIMARY);
         };
     }
 
@@ -244,6 +260,45 @@ public final class TaskStyleUtils {
 
     /** Red used for missed recurring-task occurrence accents. */
     public static final String MISSED_COLOR = "#e74c3c";
+
+    public static String attemptTextColor(StudyGoal goal) {
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
+            return COLOR_DANGER;
+        }
+        return switch (goal.getAttemptOutcome()) {
+            case ACHIEVED -> COLOR_SUCCESS;
+            case MISSED -> COLOR_DANGER;
+            case PENDING -> COLOR_PRIMARY;
+        };
+    }
+
+    public static String attemptBackgroundColor(StudyGoal goal) {
+        if (goal.getStatus() == StudyGoal.GoalStatus.ABANDONED) {
+            return TINT_DANGER;
+        }
+        return switch (goal.getAttemptOutcome()) {
+            case ACHIEVED -> TINT_SUCCESS;
+            case MISSED -> TINT_DANGER;
+            case PENDING -> TINT_PRIMARY;
+        };
+    }
+
+    public static String retryTextColor() {
+        return COLOR_ORANGE;
+    }
+
+    public static String retryBackgroundColor() {
+        return TINT_ORANGE;
+    }
+
+    public static Label createAttemptBadge(String text, String textColor, String backgroundColor) {
+        Label badge = new Label(text);
+        fontBold(badge, 10);
+        badge.setTextFill(Color.web(textColor));
+        badge.setPadding(new Insets(2, 7, 2, 7));
+        badge.setStyle("-fx-background-color: " + backgroundColor + "; -fx-background-radius: 10;");
+        return badge;
+    }
 
     /**
      * Creates a small red "Missed" badge for a past calendar date where

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -108,6 +108,7 @@ CREATE TABLE IF NOT EXISTS study_goals (
     task_id VARCHAR(50),
     replanned_for_date DATE,
     status VARCHAR(20) DEFAULT 'ACTIVE',
+    abandoned_explicitly BOOLEAN DEFAULT FALSE,
     achieved_attempt_id VARCHAR(50),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -210,6 +211,7 @@ ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS failed BOOLEAN DEFAULT FALSE;
 -- schema.sql is re-run on every startup, so destructive DROP COLUMN migrations
 -- would make the compatibility backfill below unsafe on later launches.
 ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'ACTIVE';
+ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS abandoned_explicitly BOOLEAN DEFAULT FALSE;
 ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS achieved_attempt_id VARCHAR(50);
 
 CREATE INDEX IF NOT EXISTS idx_study_goals_status ON study_goals(status);
@@ -294,10 +296,13 @@ WHERE EXISTS (
     WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
 );
 
+-- Legacy "failed" goals were missed attempts, not explicit abandonment.
+-- Keep missed-only parent goals active so users can plan another retry.
 UPDATE study_goals g
-SET status = 'ABANDONED'
-WHERE failed = TRUE
+SET status = 'ACTIVE', failed = FALSE
+WHERE status = 'ABANDONED'
+  AND COALESCE(abandoned_explicitly, FALSE) = FALSE
   AND NOT EXISTS (
       SELECT 1 FROM study_goal_attempts a
-      WHERE a.goal_id = g.id AND a.outcome IN ('PENDING', 'ACHIEVED')
+      WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
   );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -107,9 +107,28 @@ CREATE TABLE IF NOT EXISTS study_goals (
     points_deducted INTEGER DEFAULT 0,
     task_id VARCHAR(50),
     replanned_for_date DATE,
+    status VARCHAR(20) DEFAULT 'ACTIVE',
+    achieved_attempt_id VARCHAR(50),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE SET NULL
+);
+
+-- ===================================
+-- Study Goal Attempts Table
+-- ===================================
+CREATE TABLE IF NOT EXISTS study_goal_attempts (
+    id VARCHAR(50) PRIMARY KEY,
+    goal_id VARCHAR(50) NOT NULL,
+    planned_for_date DATE NOT NULL,
+    replanned_from_attempt_id VARCHAR(50),
+    outcome VARCHAR(20) DEFAULT 'PENDING',
+    reason_if_not_achieved TEXT,
+    outcome_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (goal_id) REFERENCES study_goals(id) ON DELETE CASCADE,
+    FOREIGN KEY (replanned_from_attempt_id) REFERENCES study_goal_attempts(id) ON DELETE SET NULL
 );
 
 -- ===================================
@@ -163,6 +182,9 @@ CREATE INDEX IF NOT EXISTS idx_project_sessions_project_id ON project_sessions(p
 
 CREATE INDEX IF NOT EXISTS idx_study_goals_date ON study_goals(date);
 CREATE INDEX IF NOT EXISTS idx_study_goals_is_delayed ON study_goals(is_delayed);
+CREATE INDEX IF NOT EXISTS idx_study_goal_attempts_goal_id ON study_goal_attempts(goal_id);
+CREATE INDEX IF NOT EXISTS idx_study_goal_attempts_date ON study_goal_attempts(planned_for_date);
+CREATE INDEX IF NOT EXISTS idx_study_goal_attempts_outcome ON study_goal_attempts(outcome);
 CREATE INDEX IF NOT EXISTS idx_daily_reflections_date ON daily_reflections(date);
 
 -- ===================================
@@ -183,3 +205,99 @@ ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS replanned_for_date DATE;
 -- Add failed flag to study_goals. Failed goals are kept for historical logging
 -- but excluded from active planner views.
 ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS failed BOOLEAN DEFAULT FALSE;
+
+-- Add per-attempt goal lifecycle columns. Legacy columns remain intentionally:
+-- schema.sql is re-run on every startup, so destructive DROP COLUMN migrations
+-- would make the compatibility backfill below unsafe on later launches.
+ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'ACTIVE';
+ALTER TABLE study_goals ADD COLUMN IF NOT EXISTS achieved_attempt_id VARCHAR(50);
+
+CREATE INDEX IF NOT EXISTS idx_study_goals_status ON study_goals(status);
+
+-- Backfill the first attempt from the legacy study_goals row. Existing attempt
+-- rows are left untouched so this migration is safe to re-run.
+INSERT INTO study_goal_attempts (
+    id, goal_id, planned_for_date, replanned_from_attempt_id, outcome,
+    reason_if_not_achieved, outcome_at, created_at, updated_at
+)
+SELECT
+    id || '-attempt-1',
+    id,
+    date,
+    NULL,
+    CASE
+        WHEN replanned_for_date IS NOT NULL THEN 'MISSED'
+        WHEN failed = TRUE THEN 'MISSED'
+        WHEN achieved = TRUE THEN 'ACHIEVED'
+        ELSE 'PENDING'
+    END,
+    reason_if_not_achieved,
+    CASE
+        WHEN replanned_for_date IS NOT NULL OR failed = TRUE OR achieved = TRUE THEN updated_at
+        ELSE NULL
+    END,
+    created_at,
+    updated_at
+FROM study_goals g
+WHERE NOT EXISTS (
+    SELECT 1 FROM study_goal_attempts a WHERE a.goal_id = g.id
+);
+
+-- Backfill the explicit re-plan attempt when the legacy row had one. If the
+-- re-planned goal was eventually achieved, the achieved outcome belongs to the
+-- re-plan date, while the original date remains a missed attempt.
+INSERT INTO study_goal_attempts (
+    id, goal_id, planned_for_date, replanned_from_attempt_id, outcome,
+    reason_if_not_achieved, outcome_at, created_at, updated_at
+)
+SELECT
+    id || '-attempt-2',
+    id,
+    replanned_for_date,
+    id || '-attempt-1',
+    CASE
+        WHEN achieved = TRUE THEN 'ACHIEVED'
+        WHEN failed = TRUE THEN 'MISSED'
+        ELSE 'PENDING'
+    END,
+    reason_if_not_achieved,
+    CASE
+        WHEN achieved = TRUE OR failed = TRUE THEN updated_at
+        ELSE NULL
+    END,
+    updated_at,
+    updated_at
+FROM study_goals g
+WHERE replanned_for_date IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM study_goal_attempts a WHERE a.id = g.id || '-attempt-2'
+  );
+
+UPDATE study_goals g
+SET achieved_attempt_id = (
+    SELECT a.id
+    FROM study_goal_attempts a
+    WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
+    ORDER BY a.planned_for_date DESC, a.created_at DESC
+    LIMIT 1
+)
+WHERE g.achieved_attempt_id IS NULL
+  AND EXISTS (
+      SELECT 1 FROM study_goal_attempts a
+      WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
+  );
+
+UPDATE study_goals g
+SET status = 'ACHIEVED'
+WHERE EXISTS (
+    SELECT 1 FROM study_goal_attempts a
+    WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
+);
+
+UPDATE study_goals g
+SET status = 'ABANDONED'
+WHERE failed = TRUE
+  AND NOT EXISTS (
+      SELECT 1 FROM study_goal_attempts a
+      WHERE a.goal_id = g.id AND a.outcome IN ('PENDING', 'ACHIEVED')
+  );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -273,6 +273,12 @@ FROM study_goals g
 WHERE replanned_for_date IS NOT NULL
   AND NOT EXISTS (
       SELECT 1 FROM study_goal_attempts a WHERE a.id = g.id || '-attempt-2'
+  )
+  -- Only chain onto a backfilled attempt-1. Goals whose attempts were created
+  -- through the app have UUID attempt ids, and inserting attempt-2 for them
+  -- would violate the replanned_from_attempt_id FK and abort schema init.
+  AND EXISTS (
+      SELECT 1 FROM study_goal_attempts a WHERE a.id = g.id || '-attempt-1'
   );
 
 UPDATE study_goals g
@@ -284,14 +290,18 @@ SET achieved_attempt_id = (
     LIMIT 1
 )
 WHERE g.achieved_attempt_id IS NULL
+  AND COALESCE(g.abandoned_explicitly, FALSE) = FALSE
   AND EXISTS (
       SELECT 1 FROM study_goal_attempts a
       WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
   );
 
+-- Explicitly abandoned goals stay abandoned: this backfill must not undo a
+-- user's abandon action on the next startup.
 UPDATE study_goals g
 SET status = 'ACHIEVED'
-WHERE EXISTS (
+WHERE COALESCE(g.abandoned_explicitly, FALSE) = FALSE
+  AND EXISTS (
     SELECT 1 FROM study_goal_attempts a
     WHERE a.goal_id = g.id AND a.outcome = 'ACHIEVED'
 );

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -375,6 +375,11 @@
     -fx-min-height: 100px;
 }
 
+/* ComboBox popups must fit their items, not inherit page-level ListView sizing. */
+.combo-box-popup .list-view {
+    -fx-min-height: 0;
+}
+
 /*
  * ============================================================
  * CONTEXT MENUS

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -512,6 +512,20 @@
     -fx-background-radius: 4;
 }
 
+.planner-view-toggle {
+    -fx-background-color: #ecf0f1;
+    -fx-text-fill: #2c3e50;
+    -fx-background-radius: 4;
+    -fx-border-color: #bdc3c7;
+    -fx-border-radius: 4;
+}
+
+.planner-view-toggle:selected {
+    -fx-background-color: #3498db;
+    -fx-text-fill: white;
+    -fx-border-color: #2980b9;
+}
+
 /* MODAL CONTENT */
 .modal-content {
     -fx-background-color: white;

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -187,6 +187,23 @@ class StudyServicePersistenceTest {
     }
 
     @Test
+    void explicitlyAbandonedGoalIsNotOfferedForRetry() {
+        StudyGoal goal = new StudyGoal("Drop this goal");
+        goal.setDate(LocalDate.of(2026, 3, 27));
+        goal.save();
+
+        studyService.processAllDelayedGoals();
+        assertEquals(1, StudyGoal.findDelayedAndNotReplanned().size());
+
+        assertTrue(studyService.markGoalAsFailed(goal.getId()));
+
+        StudyGoal stored = StudyGoal.findById(goal.getId()).orElseThrow();
+        assertEquals(StudyGoal.GoalStatus.ABANDONED, stored.getStatus());
+        assertTrue(stored.isAbandonedExplicitly());
+        assertTrue(StudyGoal.findDelayedAndNotReplanned().isEmpty());
+    }
+
+    @Test
     void getActiveSessionFindsSessionThatStartedPreviousDay() {
         LocalDate sessionDate = LocalDate.of(2026, 3, 27);
         LocalDateTime startTime = LocalDateTime.of(2026, 3, 27, 23, 50);
@@ -257,6 +274,7 @@ class StudyServicePersistenceTest {
                     replanned_for_date DATE,
                     failed BOOLEAN DEFAULT FALSE,
                     status VARCHAR(20) DEFAULT 'ACTIVE',
+                    abandoned_explicitly BOOLEAN DEFAULT FALSE,
                     achieved_attempt_id VARCHAR(50),
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -147,8 +147,43 @@ class StudyServicePersistenceTest {
         StudyGoal stored = StudyGoal.findById(goal.getId()).orElseThrow();
         assertTrue(stored.isAchieved());
 
+        Integer achievedAttempts = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ? AND outcome = 'ACHIEVED'",
+                Integer.class,
+                goal.getId());
+        assertEquals(1, achievedAttempts);
+
         verify(googleDriveService).markLocalDbDirty();
         verify(googleDriveService).saveLocally();
+    }
+
+    @Test
+    void overdueGoalAttemptBecomesMissedAndCanBeReplanned() {
+        StudyGoal goal = new StudyGoal("Review missed topic");
+        goal.setDate(LocalDate.of(2026, 3, 27));
+        goal.save();
+
+        reset(googleDriveService);
+        when(googleDriveService.saveLocally()).thenReturn(true);
+
+        StudyService.GoalDelayProcessingResult result = studyService.processAllDelayedGoals();
+
+        assertEquals(1, result.updatedGoals());
+        assertEquals(0, result.failedGoals());
+        assertEquals(1, StudyGoal.findDelayedAndNotReplanned().size());
+
+        studyService.replanGoalForToday(goal.getId());
+
+        List<StudyGoal> todayGoals = studyService.getStudyGoalsForDate(LocalDate.of(2026, 3, 28));
+        assertEquals(1, todayGoals.size());
+        assertEquals(2, todayGoals.getFirst().getAttemptNumber());
+        assertEquals(1, todayGoals.getFirst().getMissedAttemptCount());
+
+        Integer attempts = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ?",
+                Integer.class,
+                goal.getId());
+        assertEquals(2, attempts);
     }
 
     @Test
@@ -221,6 +256,21 @@ class StudyServicePersistenceTest {
                     task_id VARCHAR(50),
                     replanned_for_date DATE,
                     failed BOOLEAN DEFAULT FALSE,
+                    status VARCHAR(20) DEFAULT 'ACTIVE',
+                    achieved_attempt_id VARCHAR(50),
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE study_goal_attempts (
+                    id VARCHAR(50) PRIMARY KEY,
+                    goal_id VARCHAR(50) NOT NULL,
+                    planned_for_date DATE NOT NULL,
+                    replanned_from_attempt_id VARCHAR(50),
+                    outcome VARCHAR(20) DEFAULT 'PENDING',
+                    reason_if_not_achieved TEXT,
+                    outcome_at TIMESTAMP,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -177,10 +177,9 @@ class StudyServicePersistenceTest {
         StudyService.GoalDelayProcessingResult result = studyService.processAllDelayedGoals();
 
         assertEquals(1, result.missedAttempts());
-        assertEquals(0, result.abandonedGoals());
         assertEquals(1, StudyGoal.findDelayedAndNotReplanned().size());
 
-        studyService.replanGoalForToday(goal.getId());
+        assertTrue(studyService.replanGoalForToday(goal.getId()));
 
         List<StudyGoal> todayGoals = studyService.getStudyGoalsForDate(LocalDate.of(2026, 3, 28));
         assertEquals(1, todayGoals.size());
@@ -209,6 +208,24 @@ class StudyServicePersistenceTest {
         assertEquals(StudyGoal.GoalStatus.ABANDONED, stored.getStatus());
         assertTrue(stored.isAbandonedExplicitly());
         assertTrue(StudyGoal.findDelayedAndNotReplanned().isEmpty());
+    }
+
+    @Test
+    void abandonedGoalCannotBeReplannedThroughServiceOrEntity() {
+        StudyGoal abandoned = missedGoal("Abandoned retry guard", null, LocalDate.of(2026, 3, 24));
+
+        assertTrue(studyService.markGoalAsFailed(abandoned.getId()));
+        Integer beforeAttempts = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ?
+                """, Integer.class, abandoned.getId());
+
+        assertFalse(studyService.replanGoalForToday(abandoned.getId()));
+        assertFalse(StudyGoal.createReplanAttempt(abandoned.getId(), LocalDate.of(2026, 3, 28)));
+
+        Integer afterAttempts = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ?
+                """, Integer.class, abandoned.getId());
+        assertEquals(beforeAttempts, afterAttempts);
     }
 
     @Test
@@ -242,6 +259,33 @@ class StudyServicePersistenceTest {
                         .toList());
         assertTrue(studyService.getDelayedGoalsForReplanning(null).isEmpty());
         assertTrue(studyService.getDelayedGoalsForReplanning(" ").isEmpty());
+    }
+
+    @Test
+    void getUnlinkedDelayedGoalsForReplanningReturnsOnlyRetryableUnlinkedGoals() {
+        StudyGoal retryable = missedGoal("Retry without task", null, LocalDate.of(2026, 3, 24));
+        StudyGoal linked = missedGoal("Linked retry", "task-1", LocalDate.of(2026, 3, 24));
+        StudyGoal alreadyReplanned = missedGoal("Unlinked already replanned", null, LocalDate.of(2026, 3, 25));
+        StudyGoal abandoned = missedGoal("Unlinked abandoned", null, LocalDate.of(2026, 3, 26));
+        StudyGoal achieved = missedGoal("Unlinked achieved", null, LocalDate.of(2026, 3, 27));
+
+        assertTrue(StudyGoal.createReplanAttempt(alreadyReplanned.getId(), LocalDate.of(2026, 3, 28)));
+        assertTrue(studyService.markGoalAsFailed(abandoned.getId()));
+        jdbcTemplate.update("""
+                UPDATE study_goal_attempts
+                SET outcome = 'ACHIEVED', outcome_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                WHERE goal_id = ?
+                """, achieved.getId());
+        jdbcTemplate.update("""
+                UPDATE study_goals
+                SET status = 'ACHIEVED', achieved = TRUE, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """, achieved.getId());
+
+        List<StudyGoal> retries = studyService.getUnlinkedDelayedGoalsForReplanning();
+
+        assertEquals(List.of(retryable.getId()), retries.stream().map(StudyGoal::getId).toList());
+        assertFalse(retries.stream().map(StudyGoal::getId).toList().contains(linked.getId()));
     }
 
     @Test

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -176,8 +176,8 @@ class StudyServicePersistenceTest {
 
         StudyService.GoalDelayProcessingResult result = studyService.processAllDelayedGoals();
 
-        assertEquals(1, result.updatedGoals());
-        assertEquals(0, result.failedGoals());
+        assertEquals(1, result.missedAttempts());
+        assertEquals(0, result.abandonedGoals());
         assertEquals(1, StudyGoal.findDelayedAndNotReplanned().size());
 
         studyService.replanGoalForToday(goal.getId());

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -204,6 +204,34 @@ class StudyServicePersistenceTest {
     }
 
     @Test
+    void taskGoalDetailsCanBeEditedAndRetriedForChosenDate() {
+        studyService.addStudyGoal("Read chapter", LocalDate.of(2026, 3, 27), "task-1");
+
+        StudyGoal pending = StudyGoal.findByTaskId("task-1").getFirst();
+        assertTrue(studyService.updateStudyGoalDetails(
+                pending.getId(), "Read chapter and write notes", LocalDate.of(2026, 3, 29)));
+
+        StudyGoal edited = StudyGoal.findById(pending.getId()).orElseThrow();
+        assertEquals("Read chapter and write notes", edited.getDescription());
+        assertEquals(LocalDate.of(2026, 3, 29), edited.getDate());
+
+        jdbcTemplate.update("""
+                UPDATE study_goal_attempts
+                SET outcome = 'MISSED', outcome_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                WHERE goal_id = ?
+                """, edited.getId());
+
+        assertTrue(studyService.planGoalAttempt(edited.getId(), LocalDate.of(2026, 4, 2)));
+
+        List<StudyGoal> attempts = StudyGoal.findByTaskId("task-1");
+        assertEquals(2, attempts.size());
+        StudyGoal latest = StudyGoal.findById(edited.getId()).orElseThrow();
+        assertEquals(StudyGoal.AttemptOutcome.PENDING, latest.getAttemptOutcome());
+        assertEquals(LocalDate.of(2026, 4, 2), latest.getDate());
+        assertEquals(2, latest.getAttemptNumber());
+    }
+
+    @Test
     void getActiveSessionFindsSessionThatStartedPreviousDay() {
         LocalDate sessionDate = LocalDate.of(2026, 3, 27);
         LocalDateTime startTime = LocalDateTime.of(2026, 3, 27, 23, 50);

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -2,6 +2,9 @@ package com.studysync.domain.service;
 
 import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.entity.StudySession;
+import com.studysync.domain.entity.Task;
+import com.studysync.domain.valueobject.TaskPriority;
+import com.studysync.domain.valueobject.TaskStatus;
 import com.studysync.integration.drive.GoogleDriveService;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -30,6 +33,7 @@ class StudyServicePersistenceTest {
     private GoogleDriveService googleDriveService;
     private DateTimeService dateTimeService;
     private StudyService studyService;
+    private TaskService taskService;
 
     @BeforeEach
     void setUp() {
@@ -44,9 +48,11 @@ class StudyServicePersistenceTest {
         jdbcTemplate = new JdbcTemplate(dataSource);
 
         createStudySessionsTable();
+        createTasksTable();
         createStudyGoalsTable();
 
         StudySession.setJdbcTemplate(jdbcTemplate);
+        Task.setJdbcTemplate(jdbcTemplate);
         StudyGoal.setJdbcTemplate(jdbcTemplate);
 
         googleDriveService = mock(GoogleDriveService.class);
@@ -56,11 +62,13 @@ class StudyServicePersistenceTest {
         when(dateTimeService.getCurrentDate()).thenReturn(LocalDate.of(2026, 3, 28));
 
         studyService = new StudyService(googleDriveService, dateTimeService);
+        taskService = new TaskService(mock(CategoryService.class), googleDriveService, dateTimeService);
     }
 
     @AfterEach
     void tearDown() {
         StudySession.setJdbcTemplate(null);
+        Task.setJdbcTemplate(null);
         StudyGoal.setJdbcTemplate(null);
         if (dataSource != null && !dataSource.isClosed()) {
             dataSource.close();
@@ -204,6 +212,90 @@ class StudyServicePersistenceTest {
     }
 
     @Test
+    void getDelayedGoalsForReplanningReturnsOnlyRetryableGoalsForRequestedTask() {
+        StudyGoal retryable = missedGoal("Retry for requested task", "task-1", LocalDate.of(2026, 3, 24));
+        StudyGoal otherTask = missedGoal("Retry for another task", "task-2", LocalDate.of(2026, 3, 24));
+        StudyGoal alreadyReplanned = missedGoal("Already has pending retry", "task-1", LocalDate.of(2026, 3, 25));
+        StudyGoal abandoned = missedGoal("Abandoned requested task goal", "task-1", LocalDate.of(2026, 3, 26));
+        StudyGoal achieved = missedGoal("Achieved requested task goal", "task-1", LocalDate.of(2026, 3, 27));
+
+        assertTrue(StudyGoal.createReplanAttempt(alreadyReplanned.getId(), LocalDate.of(2026, 3, 28)));
+        assertTrue(studyService.markGoalAsFailed(abandoned.getId()));
+        jdbcTemplate.update("""
+                UPDATE study_goal_attempts
+                SET outcome = 'ACHIEVED', outcome_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                WHERE goal_id = ?
+                """, achieved.getId());
+        jdbcTemplate.update("""
+                UPDATE study_goals
+                SET status = 'ACHIEVED', achieved = TRUE, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """, achieved.getId());
+
+        List<StudyGoal> taskOneRetries = studyService.getDelayedGoalsForReplanning("task-1");
+
+        assertEquals(1, taskOneRetries.size());
+        assertEquals(retryable.getId(), taskOneRetries.getFirst().getId());
+        assertEquals(List.of(otherTask.getId()),
+                studyService.getDelayedGoalsForReplanning("task-2").stream()
+                        .map(StudyGoal::getId)
+                        .toList());
+        assertTrue(studyService.getDelayedGoalsForReplanning(null).isEmpty());
+        assertTrue(studyService.getDelayedGoalsForReplanning(" ").isEmpty());
+    }
+
+    @Test
+    void completedRetryHandlesOriginalMissedRecurringTaskOccurrence() {
+        LocalDate occurrenceDate = LocalDate.of(2026, 3, 30);
+        LocalDate retryDate = LocalDate.of(2026, 3, 31);
+        Task task = recurringMondayTask("recurring-task", occurrenceDate.minusWeeks(1));
+        StudyGoal goal = missedGoal("Retry original occurrence", task.getId(), occurrenceDate);
+
+        assertEquals(List.of(task.getId()), missedTaskIdsFor(retryDate));
+
+        assertTrue(StudyGoal.createReplanAttempt(goal.getId(), retryDate));
+        assertTrue(StudyGoal.markCurrentAttemptAchieved(goal.getId(), null));
+
+        assertTrue(taskService.getMissedRecurringOccurrences(retryDate).isEmpty());
+        assertTrue(taskService.isOccurrenceHandled(task, occurrenceDate));
+        assertTrue(StudyGoal.findHandledTaskDatePairs(occurrenceDate, retryDate)
+                .contains(task.getId() + "|" + occurrenceDate));
+    }
+
+    @Test
+    void unrelatedLaterAchievedGoalDoesNotHandleMissedRecurringTaskOccurrence() {
+        LocalDate occurrenceDate = LocalDate.of(2026, 3, 30);
+        LocalDate laterDate = LocalDate.of(2026, 3, 31);
+        Task task = recurringMondayTask("recurring-task", occurrenceDate.minusWeeks(1));
+        missedGoal("Missed original occurrence", task.getId(), occurrenceDate);
+        StudyGoal unrelated = new StudyGoal("Unrelated later goal");
+        unrelated.setTaskId(task.getId());
+        unrelated.setDate(laterDate);
+        unrelated.save();
+
+        assertTrue(StudyGoal.markCurrentAttemptAchieved(unrelated.getId(), null));
+
+        assertEquals(List.of(task.getId()), missedTaskIdsFor(laterDate));
+        assertFalse(taskService.isOccurrenceHandled(task, occurrenceDate));
+    }
+
+    @Test
+    void directAchievedGoalHandlesRecurringTaskOccurrence() {
+        LocalDate occurrenceDate = LocalDate.of(2026, 3, 30);
+        LocalDate nextDate = LocalDate.of(2026, 3, 31);
+        Task task = recurringMondayTask("recurring-task", occurrenceDate.minusWeeks(1));
+        StudyGoal goal = new StudyGoal("Complete scheduled occurrence");
+        goal.setTaskId(task.getId());
+        goal.setDate(occurrenceDate);
+        goal.save();
+
+        assertTrue(StudyGoal.markCurrentAttemptAchieved(goal.getId(), null));
+
+        assertTrue(taskService.getMissedRecurringOccurrences(nextDate).isEmpty());
+        assertTrue(taskService.isOccurrenceHandled(task, occurrenceDate));
+    }
+
+    @Test
     void taskGoalDetailsCanBeEditedAndRetriedForChosenDate() {
         studyService.addStudyGoal("Read chapter", LocalDate.of(2026, 3, 27), "task-1");
 
@@ -287,6 +379,25 @@ class StudyServicePersistenceTest {
                 """);
     }
 
+    private void createTasksTable() {
+        jdbcTemplate.execute("""
+                CREATE TABLE tasks (
+                    id VARCHAR(50) PRIMARY KEY,
+                    title VARCHAR(255) NOT NULL,
+                    description TEXT,
+                    category VARCHAR(100),
+                    priority INTEGER DEFAULT 1,
+                    deadline DATE,
+                    status VARCHAR(20) DEFAULT 'OPEN',
+                    points INTEGER DEFAULT 0,
+                    recurring_pattern VARCHAR(100),
+                    start_date DATE,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+    }
+
     private void createStudyGoalsTable() {
         jdbcTemplate.execute("""
                 CREATE TABLE study_goals (
@@ -321,5 +432,30 @@ class StudyServicePersistenceTest {
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
                 """);
+    }
+
+    private StudyGoal missedGoal(final String description, final String taskId, final LocalDate date) {
+        StudyGoal goal = new StudyGoal(description);
+        goal.setTaskId(taskId);
+        goal.setDate(date);
+        goal.save();
+        jdbcTemplate.update("""
+                UPDATE study_goal_attempts
+                SET outcome = 'MISSED', outcome_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                WHERE goal_id = ?
+                """, goal.getId());
+        return StudyGoal.findById(goal.getId()).orElseThrow();
+    }
+
+    private Task recurringMondayTask(final String taskId, final LocalDate startDate) {
+        Task task = new Task(taskId, "Recurring task", "", "Study", new TaskPriority(3),
+                null, TaskStatus.OPEN, 0, "1:1", startDate);
+        return task.save();
+    }
+
+    private List<String> missedTaskIdsFor(final LocalDate today) {
+        return taskService.getMissedRecurringOccurrences(today).stream()
+                .map(occurrence -> occurrence.task().getId())
+                .toList();
     }
 }

--- a/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/StudyServicePersistenceTest.java
@@ -3,6 +3,7 @@ package com.studysync.domain.service;
 import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.entity.StudySession;
 import com.studysync.domain.entity.Task;
+import com.studysync.domain.exception.ValidationException;
 import com.studysync.domain.valueobject.TaskPriority;
 import com.studysync.domain.valueobject.TaskStatus;
 import com.studysync.integration.drive.GoogleDriveService;
@@ -20,6 +21,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -226,6 +228,38 @@ class StudyServicePersistenceTest {
                 SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ?
                 """, Integer.class, abandoned.getId());
         assertEquals(beforeAttempts, afterAttempts);
+    }
+
+    @Test
+    void achievedGoalCannotBeAbandoned() {
+        StudyGoal goal = new StudyGoal("Achieved abandon guard");
+        goal.setDate(LocalDate.of(2026, 3, 27));
+        goal.save();
+        studyService.updateStudyGoalAchievement(goal.getId(), true, null);
+
+        assertFalse(studyService.markGoalAsFailed(goal.getId()));
+
+        StudyGoal stored = StudyGoal.findById(goal.getId()).orElseThrow();
+        assertEquals(StudyGoal.GoalStatus.ACHIEVED, stored.getStatus());
+        Integer achievedAttempts = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ? AND outcome = 'ACHIEVED'",
+                Integer.class,
+                goal.getId());
+        assertEquals(1, achievedAttempts);
+    }
+
+    @Test
+    void planGoalAttemptRejectsPastDates() {
+        StudyGoal goal = missedGoal("Past retry guard", null, LocalDate.of(2026, 3, 24));
+
+        assertThrows(ValidationException.class,
+                () -> studyService.planGoalAttempt(goal.getId(), LocalDate.of(2026, 3, 27)));
+
+        Integer attempts = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_goal_attempts WHERE goal_id = ?",
+                Integer.class,
+                goal.getId());
+        assertEquals(1, attempts);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Move missed-goal retry from the global Study Planner dropdown into each expanded task card
- Add Today / All Tasks planner view toggle and Reason grouping
- Fix missed recurring task detection so a completed retry handles the original missed occurrence
- Update Calendar missed badges/counts to use the same handled-occurrence logic

## Test plan
- [x] ./gradlew compileJava
- [x] ./gradlew test
- [x] ./gradlew check (passes with existing Checkstyle warnings)

## Notes
- This intentionally does not implement the future Course/session-linking migration; that should start from clean master after this PR lands.