### PR TITLE
Fix frontend getting stuck when Drive upload fails

### DIFF
--- a/src/main/java/com/studysync/application/StudySyncJavaFXApp.java
+++ b/src/main/java/com/studysync/application/StudySyncJavaFXApp.java
@@ -19,6 +19,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * JavaFX Application class that integrates with Spring Boot dependency injection.
@@ -164,7 +165,10 @@ public class StudySyncJavaFXApp extends Application {
         progressAlert.getButtonTypes().clear();
         progressAlert.show();
 
+        // The timeout backstop guarantees whenComplete fires even if the upload
+        // hangs, so the disabled UI and button-less progress alert always recover.
         CompletableFuture.supplyAsync(driveService::uploadDatabaseSnapshot)
+                .orTimeout(3, TimeUnit.MINUTES)
                 .whenComplete((result, error) -> Platform.runLater(() -> {
                     progressAlert.close();
                     shutdownInProgress = false;

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveGateway.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveGateway.java
@@ -2,6 +2,7 @@ package com.studysync.integration.drive;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.http.FileContent;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.FileList;
@@ -27,6 +28,9 @@ public class GoogleDriveGateway {
 
     private static final Logger logger = LoggerFactory.getLogger(GoogleDriveGateway.class);
 
+    private static final int HTTP_CONNECT_TIMEOUT_MS = 30_000;
+    private static final int HTTP_READ_TIMEOUT_MS = 60_000;
+
     private final GoogleDriveSettings settings;
     private final GoogleCredentialManager credentialManager;
 
@@ -37,7 +41,7 @@ public class GoogleDriveGateway {
 
     public Optional<String> fetchAccountEmail(Credential credential) {
         try {
-            Oauth2 oauth2 = new Oauth2.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(), credential)
+            Oauth2 oauth2 = new Oauth2.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(), timeoutInitializer(credential))
                     .setApplicationName(settings.applicationName())
                     .build();
             Userinfo info = oauth2.userinfo().get().execute();
@@ -150,9 +154,22 @@ public class GoogleDriveGateway {
     }
 
     private Drive buildDriveClient(Credential credential) {
-        return new Drive.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(), credential)
+        return new Drive.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(), timeoutInitializer(credential))
                 .setApplicationName(settings.applicationName())
                 .build();
+    }
+
+    /**
+     * Wraps the credential with explicit timeouts so a dead connection fails
+     * with an IOException instead of hanging Drive calls (and the UI awaiting
+     * them) forever.
+     */
+    private HttpRequestInitializer timeoutInitializer(Credential credential) {
+        return request -> {
+            credential.initialize(request);
+            request.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
+            request.setReadTimeout(HTTP_READ_TIMEOUT_MS);
+        };
     }
 
     private Optional<String> ensureAppFolder(Drive drive) throws IOException {

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveGateway.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveGateway.java
@@ -41,7 +41,8 @@ public class GoogleDriveGateway {
 
     public Optional<String> fetchAccountEmail(Credential credential) {
         try {
-            Oauth2 oauth2 = new Oauth2.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(), timeoutInitializer(credential))
+            Oauth2 oauth2 = new Oauth2.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(),
+                    timeoutInitializer(credential))
                     .setApplicationName(settings.applicationName())
                     .build();
             Userinfo info = oauth2.userinfo().get().execute();
@@ -154,7 +155,8 @@ public class GoogleDriveGateway {
     }
 
     private Drive buildDriveClient(Credential credential) {
-        return new Drive.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(), timeoutInitializer(credential))
+        return new Drive.Builder(credentialManager.httpTransport(), credentialManager.jsonFactory(),
+                timeoutInitializer(credential))
                 .setApplicationName(settings.applicationName())
                 .build();
     }

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
@@ -42,6 +42,12 @@ public class GoogleDriveService {
      * for the whole network upload and would stall every mutation.
      */
     private final Object dirtyStateLock = new Object();
+    /**
+     * Monotonic count of markLocalDbDirty() calls, guarded by dirtyStateLock.
+     * The upload fence compares generations rather than timestamps so two
+     * mutations in the same millisecond can never tie the comparison.
+     */
+    private long localMutationGeneration = 0L;
 
     public GoogleDriveService(GoogleDriveSettings settings,
                               GoogleCredentialManager credentialManager,
@@ -168,9 +174,9 @@ public class GoogleDriveService {
         // at worst a redundant re-upload, never a silently lost edit. The read
         // and the compare-and-clear are atomic w.r.t. markLocalDbDirty() via
         // dirtyStateLock; the checkpoint and network call stay outside the lock.
-        long mutationAtUploadStart;
+        long generationAtUploadStart;
         synchronized (dirtyStateLock) {
-            mutationAtUploadStart = lastLocalMutationAt;
+            generationAtUploadStart = localMutationGeneration;
         }
 
         if (!saveLocally()) {
@@ -181,7 +187,7 @@ public class GoogleDriveService {
         boolean uploaded = gateway.uploadDatabaseToDrive(activeCredential);
         if (uploaded) {
             synchronized (dirtyStateLock) {
-                if (lastLocalMutationAt == mutationAtUploadStart) {
+                if (localMutationGeneration == generationAtUploadStart) {
                     localDbDirty = false;
                     lastLocalMutationAt = 0L;
                 }
@@ -236,6 +242,7 @@ public class GoogleDriveService {
         synchronized (dirtyStateLock) {
             this.localDbDirty = true;
             this.lastLocalMutationAt = System.currentTimeMillis();
+            this.localMutationGeneration++;
         }
     }
 

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
@@ -35,6 +35,13 @@ public class GoogleDriveService {
     /** Tracks whether the local DB has been modified since the last upload to Drive. */
     private volatile boolean localDbDirty = false;
     private volatile long lastLocalMutationAt = 0L;
+    /**
+     * Guards paired reads/writes of localDbDirty + lastLocalMutationAt, so the
+     * upload thread's compare-and-clear cannot interleave with a concurrent
+     * markLocalDbDirty(). Deliberately not the service monitor — that is held
+     * for the whole network upload and would stall every mutation.
+     */
+    private final Object dirtyStateLock = new Object();
 
     public GoogleDriveService(GoogleDriveSettings settings,
                               GoogleCredentialManager credentialManager,
@@ -161,12 +168,21 @@ public class GoogleDriveService {
 
         // Fence against writes that land while the upload is in flight (or after
         // the UI has already timed out waiting for it): only clear the dirty flag
-        // if no local mutation happened since the checkpoint we uploaded.
-        long mutationAtUploadStart = lastLocalMutationAt;
+        // if no local mutation happened since the checkpoint we uploaded. The
+        // read and the compare-and-clear are atomic w.r.t. markLocalDbDirty()
+        // via dirtyStateLock; the network call stays outside the lock.
+        long mutationAtUploadStart;
+        synchronized (dirtyStateLock) {
+            mutationAtUploadStart = lastLocalMutationAt;
+        }
         boolean uploaded = gateway.uploadDatabaseToDrive(activeCredential);
-        if (uploaded && lastLocalMutationAt == mutationAtUploadStart) {
-            localDbDirty = false;
-            lastLocalMutationAt = 0L;
+        if (uploaded) {
+            synchronized (dirtyStateLock) {
+                if (lastLocalMutationAt == mutationAtUploadStart) {
+                    localDbDirty = false;
+                    lastLocalMutationAt = 0L;
+                }
+            }
         }
         return uploaded;
     }
@@ -214,8 +230,10 @@ public class GoogleDriveService {
     }
 
     public void markLocalDbDirty() {
-        this.localDbDirty = true;
-        this.lastLocalMutationAt = System.currentTimeMillis();
+        synchronized (dirtyStateLock) {
+            this.localDbDirty = true;
+            this.lastLocalMutationAt = System.currentTimeMillis();
+        }
     }
 
     public boolean isLocalDbDirty() {

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
@@ -159,8 +159,12 @@ public class GoogleDriveService {
             return false;
         }
 
+        // Fence against writes that land while the upload is in flight (or after
+        // the UI has already timed out waiting for it): only clear the dirty flag
+        // if no local mutation happened since the checkpoint we uploaded.
+        long mutationAtUploadStart = lastLocalMutationAt;
         boolean uploaded = gateway.uploadDatabaseToDrive(activeCredential);
-        if (uploaded) {
+        if (uploaded && lastLocalMutationAt == mutationAtUploadStart) {
             localDbDirty = false;
             lastLocalMutationAt = 0L;
         }

--- a/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
+++ b/src/main/java/com/studysync/integration/drive/GoogleDriveService.java
@@ -161,20 +161,23 @@ public class GoogleDriveService {
         if (!isIntegrationEnabled() || activeCredential == null) {
             return false;
         }
+        // Fence against writes that land any time after this point (during the
+        // checkpoint, the upload, or after the UI timed out waiting): only clear
+        // the dirty flag if no local mutation happened since. Captured BEFORE
+        // saveLocally() so a mutation racing the checkpoint keeps dirty=true —
+        // at worst a redundant re-upload, never a silently lost edit. The read
+        // and the compare-and-clear are atomic w.r.t. markLocalDbDirty() via
+        // dirtyStateLock; the checkpoint and network call stay outside the lock.
+        long mutationAtUploadStart;
+        synchronized (dirtyStateLock) {
+            mutationAtUploadStart = lastLocalMutationAt;
+        }
+
         if (!saveLocally()) {
             logger.warn("Aborting Drive upload because the local database could not be verified as fresh");
             return false;
         }
 
-        // Fence against writes that land while the upload is in flight (or after
-        // the UI has already timed out waiting for it): only clear the dirty flag
-        // if no local mutation happened since the checkpoint we uploaded. The
-        // read and the compare-and-clear are atomic w.r.t. markLocalDbDirty()
-        // via dirtyStateLock; the network call stays outside the lock.
-        long mutationAtUploadStart;
-        synchronized (dirtyStateLock) {
-            mutationAtUploadStart = lastLocalMutationAt;
-        }
         boolean uploaded = gateway.uploadDatabaseToDrive(activeCredential);
         if (uploaded) {
             synchronized (dirtyStateLock) {


### PR DESCRIPTION
## Summary
- Set explicit connect (30s) / read (60s) timeouts on all Google Drive and OAuth HTTP requests in `GoogleDriveGateway`, so a dead connection fails with an `IOException` instead of hanging forever — this fixes every Drive call site (Profile upload/download, sync status checks, exit flow)
- Add a 3-minute `orTimeout` backstop to the upload-and-exit future in `StudySyncJavaFXApp`, guaranteeing the button-less progress dialog closes and the disabled main window recovers even if the upload hangs for a non-network reason

Previously, a hung upload left `shutdownInProgress` stuck at `true`, which made the close handler swallow all further close requests — the window could not be closed and the process had to be killed by the OS.

Closes #32

## Test plan
- [x] ./gradlew compileJava
- [x] ./gradlew test

🤖 Generated with [Claude Code](https://claude.com/claude-code)