### PR TITLE
Add rescheduling with history for delayed and postponed tasks

### DIFF
--- a/src/main/java/com/studysync/config/ActiveRecordConfig.java
+++ b/src/main/java/com/studysync/config/ActiveRecordConfig.java
@@ -3,6 +3,7 @@ package com.studysync.config;
 import com.studysync.domain.entity.StudySession;
 import com.studysync.domain.entity.ProjectSession;
 import com.studysync.domain.entity.Task;
+import com.studysync.domain.entity.TaskReschedule;
 import com.studysync.domain.entity.Project;
 import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.entity.DailyReflection;
@@ -40,6 +41,7 @@ public class ActiveRecordConfig {
         StudySession.setJdbcTemplate(jdbcTemplate);
         ProjectSession.setJdbcTemplate(jdbcTemplate);
         Task.setJdbcTemplate(jdbcTemplate);
+        TaskReschedule.setJdbcTemplate(jdbcTemplate);
         Project.setJdbcTemplate(jdbcTemplate);
         StudyGoal.setJdbcTemplate(jdbcTemplate);
         DailyReflection.setJdbcTemplate(jdbcTemplate);

--- a/src/main/java/com/studysync/domain/entity/TaskReschedule.java
+++ b/src/main/java/com/studysync/domain/entity/TaskReschedule.java
@@ -1,0 +1,125 @@
+package com.studysync.domain.entity;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * One deadline change of a task: the date it was due before and the date
+ * it was moved to. Rows are append-only history; the current due date
+ * always lives on the task itself.
+ *
+ * <p>Uses Active Record pattern - handles its own database operations.</p>
+ *
+ * @since 0.1.5
+ */
+public class TaskReschedule {
+    private static final Logger logger = LoggerFactory.getLogger(TaskReschedule.class);
+    private static JdbcTemplate jdbcTemplate;
+
+    public static void setJdbcTemplate(JdbcTemplate template) {
+        jdbcTemplate = template;
+    }
+
+    private String id;
+    private String taskId;
+    private LocalDate oldDeadline;
+    private LocalDate newDeadline;
+    private LocalDateTime rescheduledAt;
+
+    public TaskReschedule() {
+    }
+
+    public TaskReschedule(String taskId, LocalDate oldDeadline, LocalDate newDeadline) {
+        this.taskId = taskId;
+        this.oldDeadline = oldDeadline;
+        this.newDeadline = newDeadline;
+        this.rescheduledAt = LocalDateTime.now();
+    }
+
+    /**
+     * Insert this reschedule event into the database.
+     */
+    public TaskReschedule save() {
+        if (jdbcTemplate == null) {
+            throw new IllegalStateException("JdbcTemplate not initialized. Make sure Spring context is loaded.");
+        }
+
+        if (this.id == null || this.id.isBlank()) {
+            this.id = UUID.randomUUID().toString();
+        }
+
+        String sql = """
+            INSERT INTO task_reschedules (id, task_id, old_deadline, new_deadline, rescheduled_at)
+            VALUES (?, ?, ?, ?, ?)
+            """;
+
+        jdbcTemplate.update(sql,
+            this.id,
+            this.taskId,
+            this.oldDeadline,
+            this.newDeadline,
+            this.rescheduledAt
+        );
+
+        logger.debug("Task reschedule saved: task {} moved {} -> {}", taskId, oldDeadline, newDeadline);
+        return this;
+    }
+
+    /**
+     * All reschedules of a task, most recent first.
+     */
+    public static List<TaskReschedule> findByTaskId(String taskId) {
+        if (jdbcTemplate == null) {
+            throw new IllegalStateException("JdbcTemplate not initialized");
+        }
+        if (taskId == null || taskId.isBlank()) {
+            return List.of();
+        }
+
+        String sql = "SELECT * FROM task_reschedules WHERE task_id = ? ORDER BY rescheduled_at DESC";
+        return jdbcTemplate.query(sql, getRowMapper(), taskId);
+    }
+
+    private static RowMapper<TaskReschedule> getRowMapper() {
+        return (rs, rowNum) -> {
+            TaskReschedule reschedule = new TaskReschedule();
+            reschedule.id = rs.getString("id");
+            reschedule.taskId = rs.getString("task_id");
+            reschedule.oldDeadline = rs.getDate("old_deadline") != null
+                ? rs.getDate("old_deadline").toLocalDate() : null;
+            reschedule.newDeadline = rs.getDate("new_deadline") != null
+                ? rs.getDate("new_deadline").toLocalDate() : null;
+            reschedule.rescheduledAt = rs.getTimestamp("rescheduled_at") != null
+                ? rs.getTimestamp("rescheduled_at").toLocalDateTime() : null;
+            return reschedule;
+        };
+    }
+
+    // Getters
+    public String getId() {
+        return id;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public LocalDate getOldDeadline() {
+        return oldDeadline;
+    }
+
+    public LocalDate getNewDeadline() {
+        return newDeadline;
+    }
+
+    public LocalDateTime getRescheduledAt() {
+        return rescheduledAt;
+    }
+}

--- a/src/main/java/com/studysync/domain/entity/TaskReschedule.java
+++ b/src/main/java/com/studysync/domain/entity/TaskReschedule.java
@@ -7,7 +7,11 @@ import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -85,6 +89,28 @@ public class TaskReschedule {
 
         String sql = "SELECT * FROM task_reschedules WHERE task_id = ? ORDER BY rescheduled_at DESC";
         return jdbcTemplate.query(sql, getRowMapper(), taskId);
+    }
+
+    /**
+     * Latest reschedule per task for a batch of task ids — one query instead
+     * of one per task card.
+     */
+    public static Map<String, TaskReschedule> findLatestByTaskIds(Collection<String> taskIds) {
+        if (jdbcTemplate == null) {
+            throw new IllegalStateException("JdbcTemplate not initialized");
+        }
+        if (taskIds == null || taskIds.isEmpty()) {
+            return Map.of();
+        }
+
+        String placeholders = String.join(",", Collections.nCopies(taskIds.size(), "?"));
+        String sql = "SELECT * FROM task_reschedules WHERE task_id IN (" + placeholders + ")"
+                + " ORDER BY rescheduled_at DESC";
+        Map<String, TaskReschedule> latest = new HashMap<>();
+        for (TaskReschedule reschedule : jdbcTemplate.query(sql, getRowMapper(), taskIds.toArray())) {
+            latest.putIfAbsent(reschedule.getTaskId(), reschedule);
+        }
+        return latest;
     }
 
     private static RowMapper<TaskReschedule> getRowMapper() {

--- a/src/main/java/com/studysync/domain/service/TaskService.java
+++ b/src/main/java/com/studysync/domain/service/TaskService.java
@@ -3,6 +3,7 @@ package com.studysync.domain.service;
 import com.studysync.domain.exception.ValidationException;
 import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.entity.Task;
+import com.studysync.domain.entity.TaskReschedule;
 import com.studysync.domain.valueobject.TaskPriority;
 import com.studysync.domain.valueobject.TaskStatus;
 import com.studysync.integration.drive.GoogleDriveService;
@@ -25,6 +26,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -158,11 +160,30 @@ public class TaskService {
         validateTaskExists(task);
         Task updated = applyTaskUpdates(task, update);
         Task finalTask = applyBusinessRules(updated);
-        
+
         Task savedTask = finalTask.save();
+        if (!Objects.equals(task.getDeadline(), savedTask.getDeadline()) && savedTask.getDeadline() != null) {
+            new TaskReschedule(savedTask.getId(), task.getDeadline(), savedTask.getDeadline()).save();
+            logger.info("Recorded reschedule for task '{}': {} -> {}",
+                    savedTask.getTitle(), task.getDeadline(), savedTask.getDeadline());
+        }
         logger.info("Updated task: {}", savedTask.getTitle());
         markDirtyAndSaveLocally("task update");
         return savedTask;
+    }
+
+    /**
+     * Moves a task to a new due date, recording the change in the reschedule
+     * history. For a DELAYED task this also revives it (status back to OPEN);
+     * for a POSTPONED task the new deadline acts as the resume date and the
+     * status is left alone until the daily pass resurfaces it.
+     */
+    @Transactional
+    public Task rescheduleTask(@NotNull Task task, @NotNull LocalDate newDeadline) {
+        if (newDeadline == null) {
+            throw ValidationException.requiredFieldMissing("newDeadline");
+        }
+        return updateTask(task, new TaskUpdate(null, null, null, null, newDeadline, null, null));
     }
     
     @Transactional
@@ -228,23 +249,36 @@ public class TaskService {
             lastDelayedTasksProcessedDate = today;
         }
 
+        // Resurface postponed tasks whose resume date (their deadline) has
+        // arrived. Ones whose date is already in the past fall through to
+        // the DELAYED sweep below — they did miss their resume date.
+        int updatedCount = 0;
+        for (Task task : Task.findByStatus(TaskStatus.POSTPONED)) {
+            if (task.getDeadline() != null && !task.getDeadline().isAfter(today)) {
+                task.updateStatus(TaskStatus.OPEN);
+                task.save();
+                updatedCount++;
+                logger.info("Postponed task '{}' resumed as OPEN", task.getTitle());
+            }
+        }
+
         List<Task> delayedTasks = Task.findAll().stream()
                 .filter(task -> task.getStatus() != TaskStatus.COMPLETED &&
                                  task.getStatus() != TaskStatus.CANCELLED &&
+                                 task.getStatus() != TaskStatus.POSTPONED &&
                                  task.getDeadline() != null &&
                                  task.getDeadline().isBefore(today) &&
                                  task.getStatus() != TaskStatus.DELAYED)
                 .map(this::applyBusinessRules)
                 .collect(Collectors.toList());
 
-        int updatedCount = 0;
         for (Task task : delayedTasks) {
             task.save();
             updatedCount++;
         }
 
         if (updatedCount > 0) {
-            logger.info("Marked {} tasks as DELAYED", updatedCount);
+            logger.info("Updated {} tasks in the daily delayed/postponed pass", updatedCount);
             markDirtyAndSaveLocally("delayed task processing");
         }
 
@@ -511,8 +545,9 @@ public class TaskService {
         
         LocalDate newDeadline = task.getDeadline();
         if (update.deadline() != null) {
-            if (update.deadline().isBefore(LocalDate.now())) {
-                throw ValidationException.invalidDateRange(update.deadline().toString(), LocalDate.now().toString());
+            LocalDate today = dateTimeService.getCurrentDate();
+            if (update.deadline().isBefore(today)) {
+                throw ValidationException.invalidDateRange(update.deadline().toString(), today.toString());
             }
             newDeadline = update.deadline();
         }
@@ -543,15 +578,26 @@ public class TaskService {
     }
     
     private Task applyBusinessRules(Task task) {
+        LocalDate today = dateTimeService.getCurrentDate();
         // Only mark non-recurring tasks as DELAYED for overdue deadlines.
         // For recurring tasks, the deadline is an end-of-recurrence boundary,
         // not a due date, so it should not trigger DELAYED status.
+        // COMPLETED and CANCELLED are terminal; POSTPONED keeps its resume
+        // date until markDelayedTasks resurfaces it.
+        boolean delayEligible = task.getStatus() != TaskStatus.COMPLETED
+                && task.getStatus() != TaskStatus.CANCELLED
+                && task.getStatus() != TaskStatus.POSTPONED;
         if (!task.isRecurring()
                 && task.getDeadline() != null
-                && task.getDeadline().isBefore(LocalDate.now())
-                && task.getStatus() != TaskStatus.COMPLETED) {
+                && task.getDeadline().isBefore(today)
+                && delayEligible) {
             logger.info("Task '{}' marked as DELAYED due to overdue deadline", task.getTitle());
             task.updateStatus(TaskStatus.DELAYED);
+        } else if (task.getStatus() == TaskStatus.DELAYED) {
+            // The deadline was removed or moved to today/future — the task
+            // is no longer late, so a rescheduled DELAYED task revives.
+            logger.info("Task '{}' no longer overdue, reset to OPEN", task.getTitle());
+            task.updateStatus(TaskStatus.OPEN);
         }
         return task;
     }

--- a/src/main/java/com/studysync/domain/service/TaskService.java
+++ b/src/main/java/com/studysync/domain/service/TaskService.java
@@ -250,16 +250,20 @@ public class TaskService {
         }
 
         // Resurface postponed tasks whose resume date (their deadline) has
-        // arrived. Ones whose date is already in the past fall through to
-        // the DELAYED sweep below — they did miss their resume date.
+        // arrived: OPEN when it resumes today, straight to DELAYED when the
+        // resume date was already missed (recurring tasks never go DELAYED,
+        // matching applyBusinessRules).
         int updatedCount = 0;
         for (Task task : Task.findByStatus(TaskStatus.POSTPONED)) {
-            if (task.getDeadline() != null && !task.getDeadline().isAfter(today)) {
-                task.updateStatus(TaskStatus.OPEN);
-                task.save();
-                updatedCount++;
-                logger.info("Postponed task '{}' resumed as OPEN", task.getTitle());
+            if (task.getDeadline() == null || task.getDeadline().isAfter(today)) {
+                continue;
             }
+            boolean missed = !task.isRecurring() && task.getDeadline().isBefore(today);
+            task.updateStatus(missed ? TaskStatus.DELAYED : TaskStatus.OPEN);
+            task.save();
+            updatedCount++;
+            logger.info("Postponed task '{}' {}", task.getTitle(),
+                    missed ? "missed its resume date, marked DELAYED" : "resumed as OPEN");
         }
 
         List<Task> delayedTasks = Task.findAll().stream()

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -4,6 +4,7 @@ package com.studysync.presentation.ui.components;
 import com.studysync.domain.entity.StudyGoal;
 import com.studysync.domain.entity.Task;
 import com.studysync.domain.entity.TaskReminder;
+import com.studysync.domain.entity.TaskReschedule;
 import com.studysync.domain.valueobject.TaskCategory;
 import com.studysync.domain.valueobject.TaskPriority;
 import com.studysync.domain.valueobject.TaskStatus;
@@ -271,6 +272,13 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         editBtn.getStyleClass().addAll("btn-primary", "btn-small");
         editBtn.setOnAction(e -> showTaskForm(task));
 
+        if (task.getStatus() == TaskStatus.DELAYED || task.getStatus() == TaskStatus.POSTPONED) {
+            Button rescheduleBtn = new Button("Reschedule");
+            rescheduleBtn.getStyleClass().addAll("btn-small");
+            rescheduleBtn.setOnAction(e -> showRescheduleDialog(task));
+            actions.getChildren().add(rescheduleBtn);
+        }
+
         if (task.getStatus() != TaskStatus.COMPLETED && task.getStatus() != TaskStatus.CANCELLED) {
             Button completeBtn = new Button("Done");
             completeBtn.getStyleClass().addAll("btn-success", "btn-small");
@@ -326,10 +334,22 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
             boolean overdue = task.getDeadline().isBefore(LocalDate.now())
                     && task.getStatus() != TaskStatus.COMPLETED
                     && task.getStatus() != TaskStatus.CANCELLED;
-            Label deadlineLabel = new Label("Due: " + task.getDeadline().toString());
+            String dueText = task.getStatus() == TaskStatus.POSTPONED
+                    ? "Postponed until: " + task.getDeadline()
+                    : "Due: " + task.getDeadline();
+            Label deadlineLabel = new Label(dueText);
             TaskStyleUtils.fontNormal(deadlineLabel, 12);
             deadlineLabel.setTextFill(overdue ? Color.web("#c0392b") : Color.web("#495057"));
             metaRow.getChildren().add(deadlineLabel);
+        }
+
+        // ponytail: per-card history query; batch-load if task lists ever get big
+        List<TaskReschedule> reschedules = TaskReschedule.findByTaskId(task.getId());
+        if (!reschedules.isEmpty() && reschedules.get(0).getOldDeadline() != null) {
+            Label prevDueLabel = new Label("Previously due: " + reschedules.get(0).getOldDeadline());
+            TaskStyleUtils.fontNormal(prevDueLabel, 11);
+            prevDueLabel.setTextFill(Color.web("#9aa0a6"));
+            metaRow.getChildren().add(prevDueLabel);
         }
 
         if (task.isRecurring()) {
@@ -913,13 +933,23 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         deadlineHint.setVisible(false);
         deadlineHint.setManaged(false);
 
+        Runnable updateDeadlineHint = () -> {
+            String text = recurringCheck.isSelected()
+                    ? "For recurring tasks, the deadline acts as the end-of-recurrence date."
+                    : statusCombo.getValue() == TaskStatus.POSTPONED
+                        ? "For postponed tasks, the deadline is the resume date - the task returns to the planner on that day."
+                        : "";
+            deadlineHint.setText(text);
+            deadlineHint.setVisible(!text.isEmpty());
+            deadlineHint.setManaged(!text.isEmpty());
+        };
         recurringCheck.selectedProperty().addListener((obs, o, n) -> {
             recurringOptions.setVisible(n);
             recurringOptions.setManaged(n);
-            deadlineHint.setVisible(n);
-            deadlineHint.setManaged(n);
-            deadlineHint.setText(n ? "For recurring tasks, the deadline acts as the end-of-recurrence date." : "");
+            updateDeadlineHint.run();
         });
+        statusCombo.valueProperty().addListener((obs, o, n) -> updateDeadlineHint.run());
+        updateDeadlineHint.run();
 
         // Pre-fill recurring pattern if editing
         if (!isNew && existingTask.isRecurring()) {
@@ -1009,6 +1039,24 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
 
         if (!isNew) {
             form.getChildren().addAll(new Label("Status:"), statusCombo);
+
+            List<TaskReschedule> history = TaskReschedule.findByTaskId(existingTask.getId());
+            if (!history.isEmpty()) {
+                VBox historyBox = new VBox(3);
+                Label historyTitle = new Label("Reschedule history:");
+                TaskStyleUtils.fontBold(historyTitle, 12);
+                historyBox.getChildren().add(historyTitle);
+                for (TaskReschedule r : history) {
+                    String from = r.getOldDeadline() != null ? r.getOldDeadline().toString() : "no deadline";
+                    String when = r.getRescheduledAt() != null
+                            ? " (changed " + r.getRescheduledAt().toLocalDate() + ")" : "";
+                    Label row = new Label(from + " -> " + r.getNewDeadline() + when);
+                    TaskStyleUtils.fontNormal(row, 11);
+                    row.setTextFill(Color.web("#7f8c8d"));
+                    historyBox.getChildren().add(row);
+                }
+                form.getChildren().add(historyBox);
+            }
         }
 
         form.getChildren().addAll(recurringCheck, recurringOptions, btnRow);
@@ -1095,6 +1143,35 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         for (Tab tab : statusTabPane.getTabs()) {
             tab.setContent(buildTaskList((String) tab.getUserData()));
         }
+    }
+
+    /**
+     * Quick reschedule for delayed/postponed tasks: one date picker, no full edit form.
+     */
+    private void showRescheduleDialog(Task task) {
+        Dialog<LocalDate> dialog = new Dialog<>();
+        dialog.setTitle("Reschedule Task");
+        dialog.setHeaderText(task.getStatus() == TaskStatus.POSTPONED
+                ? "Pick the date this task should resume on."
+                : "Pick a new due date.");
+        dialog.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
+
+        DatePicker picker = new DatePicker(LocalDate.now().plusDays(1));
+        picker.setMaxWidth(Double.MAX_VALUE);
+        dialog.getDialogPane().setContent(picker);
+        dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+        dialog.setResultConverter(bt -> bt == ButtonType.OK ? picker.getValue() : null);
+
+        dialog.showAndWait().ifPresent(newDate -> {
+            try {
+                taskService.rescheduleTask(task, newDate);
+                rebuildAllTabs();
+            } catch (Exception ex) {
+                Alert err = new Alert(Alert.AlertType.ERROR, ex.getMessage(), ButtonType.OK);
+                err.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
+                err.showAndWait();
+            }
+        });
     }
 
     // ──────────────────────────────────────────────

--- a/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/TaskManagementPanel.java
@@ -190,8 +190,10 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
             empty.setPadding(new Insets(30));
             listBox.getChildren().add(empty);
         } else {
+            Map<String, TaskReschedule> latestReschedules = TaskReschedule.findLatestByTaskIds(
+                    tasks.stream().map(Task::getId).collect(Collectors.toList()));
             for (Task task : tasks) {
-                listBox.getChildren().add(buildTaskCard(task));
+                listBox.getChildren().add(buildTaskCard(task, latestReschedules.get(task.getId())));
             }
         }
 
@@ -203,7 +205,7 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
         return sp;
     }
 
-    private VBox buildTaskCard(Task task) {
+    private VBox buildTaskCard(Task task, TaskReschedule latestReschedule) {
         VBox wrapper = new VBox(0);
         wrapper.setMaxWidth(Double.MAX_VALUE);
 
@@ -343,10 +345,8 @@ public class TaskManagementPanel extends ScrollPane implements RefreshablePanel 
             metaRow.getChildren().add(deadlineLabel);
         }
 
-        // ponytail: per-card history query; batch-load if task lists ever get big
-        List<TaskReschedule> reschedules = TaskReschedule.findByTaskId(task.getId());
-        if (!reschedules.isEmpty() && reschedules.get(0).getOldDeadline() != null) {
-            Label prevDueLabel = new Label("Previously due: " + reschedules.get(0).getOldDeadline());
+        if (latestReschedule != null && latestReschedule.getOldDeadline() != null) {
+            Label prevDueLabel = new Label("Previously due: " + latestReschedule.getOldDeadline());
             TaskStyleUtils.fontNormal(prevDueLabel, 11);
             prevDueLabel.setTextFill(Color.web("#9aa0a6"));
             metaRow.getChildren().add(prevDueLabel);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -20,6 +20,21 @@ CREATE TABLE IF NOT EXISTS tasks (
 );
 
 -- ===================================
+-- Task Reschedules Table
+-- ===================================
+-- Full history of task deadline changes: one row per reschedule.
+-- For DELAYED tasks a reschedule sets a fresh due date; for POSTPONED
+-- tasks the new deadline acts as the "resume on" date.
+CREATE TABLE IF NOT EXISTS task_reschedules (
+    id VARCHAR(50) PRIMARY KEY,
+    task_id VARCHAR(50) NOT NULL,
+    old_deadline DATE,
+    new_deadline DATE NOT NULL,
+    rescheduled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+-- ===================================
 -- Projects Table
 -- ===================================
 CREATE TABLE IF NOT EXISTS projects (
@@ -177,6 +192,7 @@ VALUES
 CREATE INDEX IF NOT EXISTS idx_tasks_category ON tasks(category);
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_deadline ON tasks(deadline);
+CREATE INDEX IF NOT EXISTS idx_task_reschedules_task_id ON task_reschedules(task_id);
 
 CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
 CREATE INDEX IF NOT EXISTS idx_projects_category ON projects(category);

--- a/src/test/java/com/studysync/domain/service/TaskServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/TaskServicePersistenceTest.java
@@ -15,6 +15,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -163,6 +164,24 @@ class TaskServicePersistenceTest {
 
         assertTrue(TaskReschedule.findByTaskId("task-4").isEmpty());
         assertEquals(TODAY.plusDays(3), Task.findById("task-4").orElseThrow().getDeadline());
+    }
+
+    @Test
+    void findLatestByTaskIdsReturnsMostRecentReschedulePerTask() {
+        savedTask("task-5", TODAY.plusDays(1), TaskStatus.OPEN);
+        jdbcTemplate.update(
+                "INSERT INTO task_reschedules (id, task_id, old_deadline, new_deadline, rescheduled_at) VALUES (?, ?, ?, ?, ?)",
+                "r1", "task-5", TODAY.plusDays(1), TODAY.plusDays(2), TODAY.minusDays(1).atTime(9, 0));
+        jdbcTemplate.update(
+                "INSERT INTO task_reschedules (id, task_id, old_deadline, new_deadline, rescheduled_at) VALUES (?, ?, ?, ?, ?)",
+                "r2", "task-5", TODAY.plusDays(2), TODAY.plusDays(4), TODAY.atTime(9, 0));
+
+        Map<String, TaskReschedule> latest =
+                TaskReschedule.findLatestByTaskIds(List.of("task-5", "no-such-task"));
+
+        assertEquals(1, latest.size());
+        assertEquals(TODAY.plusDays(2), latest.get("task-5").getOldDeadline());
+        assertEquals(TODAY.plusDays(4), latest.get("task-5").getNewDeadline());
     }
 
     private Task savedTask(final String id, final LocalDate deadline, final TaskStatus status) {

--- a/src/test/java/com/studysync/domain/service/TaskServicePersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/TaskServicePersistenceTest.java
@@ -1,0 +1,173 @@
+package com.studysync.domain.service;
+
+import com.studysync.domain.entity.Task;
+import com.studysync.domain.entity.TaskReschedule;
+import com.studysync.domain.exception.ValidationException;
+import com.studysync.domain.valueobject.TaskPriority;
+import com.studysync.domain.valueobject.TaskStatus;
+import com.studysync.integration.drive.GoogleDriveService;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TaskServicePersistenceTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 3, 28);
+
+    private HikariDataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+    private TaskService taskService;
+
+    @BeforeEach
+    void setUp() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:studysync-tasks-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        config.setUsername("sa");
+        config.setPassword("");
+        config.setMaximumPoolSize(2);
+        config.setMinimumIdle(1);
+
+        dataSource = new HikariDataSource(config);
+        jdbcTemplate = new JdbcTemplate(dataSource);
+
+        jdbcTemplate.execute("""
+                CREATE TABLE tasks (
+                    id VARCHAR(50) PRIMARY KEY,
+                    title VARCHAR(255) NOT NULL,
+                    description TEXT,
+                    category VARCHAR(100),
+                    priority INTEGER DEFAULT 1,
+                    deadline DATE,
+                    status VARCHAR(20) DEFAULT 'OPEN',
+                    points INTEGER DEFAULT 0,
+                    recurring_pattern VARCHAR(100),
+                    start_date DATE,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE task_reschedules (
+                    id VARCHAR(50) PRIMARY KEY,
+                    task_id VARCHAR(50) NOT NULL,
+                    old_deadline DATE,
+                    new_deadline DATE NOT NULL,
+                    rescheduled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+                )
+                """);
+
+        Task.setJdbcTemplate(jdbcTemplate);
+        TaskReschedule.setJdbcTemplate(jdbcTemplate);
+
+        GoogleDriveService googleDriveService = mock(GoogleDriveService.class);
+        when(googleDriveService.saveLocally()).thenReturn(true);
+
+        DateTimeService dateTimeService = mock(DateTimeService.class);
+        when(dateTimeService.getCurrentDate()).thenReturn(TODAY);
+
+        taskService = new TaskService(mock(CategoryService.class), googleDriveService, dateTimeService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Task.setJdbcTemplate(null);
+        TaskReschedule.setJdbcTemplate(null);
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void reschedulingDelayedTaskRecordsHistoryAndRevivesIt() {
+        Task task = savedTask("task-1", TODAY.minusDays(8), TaskStatus.DELAYED);
+
+        taskService.rescheduleTask(task, TODAY.plusDays(2));
+
+        Task stored = Task.findById("task-1").orElseThrow();
+        assertEquals(TODAY.plusDays(2), stored.getDeadline());
+        assertEquals(TaskStatus.OPEN, stored.getStatus());
+
+        List<TaskReschedule> history = TaskReschedule.findByTaskId("task-1");
+        assertEquals(1, history.size());
+        assertEquals(TODAY.minusDays(8), history.get(0).getOldDeadline());
+        assertEquals(TODAY.plusDays(2), history.get(0).getNewDeadline());
+    }
+
+    @Test
+    void rescheduleRejectsPastDates() {
+        Task task = savedTask("task-2", TODAY.minusDays(3), TaskStatus.DELAYED);
+
+        assertThrows(ValidationException.class,
+                () -> taskService.rescheduleTask(task, TODAY.minusDays(1)));
+        assertEquals(TaskStatus.DELAYED, Task.findById("task-2").orElseThrow().getStatus());
+        assertTrue(TaskReschedule.findByTaskId("task-2").isEmpty());
+    }
+
+    @Test
+    void reschedulingTaskWithoutDeadlineRecordsNullOldDate() {
+        Task task = savedTask("task-3", null, TaskStatus.OPEN);
+
+        taskService.rescheduleTask(task, TODAY.plusDays(5));
+
+        List<TaskReschedule> history = TaskReschedule.findByTaskId("task-3");
+        assertEquals(1, history.size());
+        assertNull(history.get(0).getOldDeadline());
+        assertEquals(TODAY.plusDays(5), history.get(0).getNewDeadline());
+    }
+
+    @Test
+    void markDelayedTasksResumesPostponedTasksWhoseDateArrived() {
+        savedTask("resume-today", TODAY, TaskStatus.POSTPONED);
+        savedTask("resume-missed", TODAY.minusDays(5), TaskStatus.POSTPONED);
+        savedTask("resume-later", TODAY.plusDays(5), TaskStatus.POSTPONED);
+
+        taskService.markDelayedTasks();
+
+        assertEquals(TaskStatus.OPEN, Task.findById("resume-today").orElseThrow().getStatus());
+        // Missed its resume date entirely, so it falls through to the DELAYED sweep.
+        assertEquals(TaskStatus.DELAYED, Task.findById("resume-missed").orElseThrow().getStatus());
+        assertEquals(TaskStatus.POSTPONED, Task.findById("resume-later").orElseThrow().getStatus());
+    }
+
+    @Test
+    void editingPostponedOrCancelledTaskDoesNotReMarkItDelayed() {
+        Task postponed = savedTask("postponed-old", TODAY.minusDays(10), TaskStatus.POSTPONED);
+        Task cancelled = savedTask("cancelled-old", TODAY.minusDays(10), TaskStatus.CANCELLED);
+
+        taskService.updateTask(postponed, new TaskUpdate("Renamed postponed", null, null, null, null));
+        taskService.updateTask(cancelled, new TaskUpdate("Renamed cancelled", null, null, null, null));
+
+        assertEquals(TaskStatus.POSTPONED, Task.findById("postponed-old").orElseThrow().getStatus());
+        assertEquals(TaskStatus.CANCELLED, Task.findById("cancelled-old").orElseThrow().getStatus());
+    }
+
+    @Test
+    void updateWithUnchangedDeadlineRecordsNoHistory() {
+        Task task = savedTask("task-4", TODAY.plusDays(3), TaskStatus.OPEN);
+
+        taskService.updateTask(task, new TaskUpdate("Renamed only", null, null, null, null));
+
+        assertTrue(TaskReschedule.findByTaskId("task-4").isEmpty());
+        assertEquals(TODAY.plusDays(3), Task.findById("task-4").orElseThrow().getDeadline());
+    }
+
+    private Task savedTask(final String id, final LocalDate deadline, final TaskStatus status) {
+        Task task = new Task(id, "Task " + id, "", "Study", new TaskPriority(3),
+                deadline, status, 0, "", null);
+        return task.save();
+    }
+}


### PR DESCRIPTION
## Problem

Delayed and postponed task management were dead ends:

- A **DELAYED** task (auto-set when a deadline passes) kept its missed deadline forever and surfaced in the planner every day. Editing the deadline to a future date did **not** reset the status — nothing ever un-marked DELAYED.
- A **POSTPONED** task vanished from the daily planner with no return date; it only reappeared if the user manually flipped its status back.
- Latent bug: `applyBusinessRules` re-marked POSTPONED and CANCELLED tasks as DELAYED on any edit — it only excluded COMPLETED.

## Changes

- **New `task_reschedules` table** — full history of deadline changes (old date → new date, timestamp), one row per reschedule. FK to tasks with `ON DELETE CASCADE`; idempotent `CREATE TABLE IF NOT EXISTS` (schema.sql re-runs on every startup — verified by applying twice to one H2 DB).
- **`TaskReschedule` entity** (Active Record, wired in `ActiveRecordConfig`).
- **`TaskService`**
  - `updateTask` records a history row whenever the deadline actually changes — the single choke point both UI paths route through.
  - New `rescheduleTask(task, newDeadline)` thin wrapper for the quick button; rejects past dates via the existing validation.
  - `applyBusinessRules`: a DELAYED task whose deadline is no longer in the past is revived to OPEN; POSTPONED/CANCELLED are no longer re-marked DELAYED.
  - `markDelayedTasks`: a POSTPONED task's deadline acts as its **resume date** — the daily pass flips it back to OPEN when the date arrives; a missed resume date falls through to the DELAYED sweep.
- **UI (`TaskManagementPanel`)**
  - **Reschedule** quick button on DELAYED/POSTPONED cards (single date picker dialog).
  - Postponed cards show `Postponed until: <date>`; rescheduled tasks show a muted `Previously due: <date>`.
  - Edit dialog: read-only reschedule history list, and the deadline hint explains the resume-date semantics when status is Postponed.

## Testing

- New `TaskServicePersistenceTest` (in-memory H2, same pattern as `StudyServicePersistenceTest`), 6 tests: revive-on-reschedule + history row, past-date rejection, null-old-deadline history, resume date arrived/missed/future, no re-mark on edit of postponed/cancelled, no history row when deadline unchanged.
- Full `./gradlew test` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)