### PR TITLE
Bump version to 0.1.6 and refresh docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@
 │                Simplified Service Layer                     │
 │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────┐  │
 │  │   TaskService   │  │  StudyService   │  │ProjectService│ │
-│  │ CategoryService │  │ ReminderService │  │   ...more   │  │
+│  │ CategoryService │  │  ScoringService │  │   ...more   │  │
 │  │ (Business Logic │  │   Orchestration) │  │             │  │
 │  └─────────────────┘  └─────────────────┘  └─────────────┘  │
 └─────────────────────────────────────────────────────────────┘
@@ -32,7 +32,7 @@
 │  └─────────────────┘  └─────────────────┘  └─────────────┘  │
 │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────┐  │
 │  │ ProjectSession  │  │   TaskPriority  │  │TaskCategory │  │
-│  │  • save()       │  │   TaskStatus    │  │DailyReflection│
+│  │  OffDay         │  │   TaskStatus    │  │DailyReflection│
 │  │  • delete()     │  │  ProjectStatus  │  │   ...more   │  │
 │  │  • findAll()    │  │  (Value Objects)│  │             │  │
 │  └─────────────────┘  └─────────────────┘  └─────────────┘  │
@@ -69,21 +69,38 @@ Tasks support an optional recurrence schedule via a `recurring_pattern` column:
 
 - **Format**: `"intervalWeeks:daysOfWeek"` — e.g. `"1:1,3,5"` = every week on Mon, Wed, Fri; `"2:1,4"` = every 2 weeks on Mon, Thu
 - **NULL** means a one-off (non-recurring) task
+- `recurrence_end_date` is the last date an occurrence may fall on; NULL means it never ends. Before 0.1.6 this was conflated with `deadline`, which left recurring tasks unable to express a real due date
+- `deadline` means the same thing on recurring and one-off tasks: when the task is due. It drives overdue badges and the timeliness part of the score, and deliberately does *not* affect whether an occurrence appears
 - `Task.isRecurring()` and `Task.getRecurringSummary()` provide runtime helpers
-- `TaskService.recurringTaskAppliesTo(task, date, referenceMonday)` checks whether a recurring task should appear on a given date
-- When editing, `""` (empty string) in `TaskUpdate.recurringPattern` signals "clear the pattern", while `null` means "keep existing"
+- `TaskService.isRecurringOccurrence(task, date)` answers "does the schedule land here", which is a different question from `taskSurfacesOn(task, date)`: a late recurring task also surfaces every day past its deadline until resolved. Anything counting missed occurrences must use the former
+- When editing, `""` (empty string) in `TaskUpdate.recurringPattern` signals "clear the pattern", while `null` means "keep existing". `TaskUpdate.CLEAR_REMINDER` plays the same role for the reminder offset
+
+### **Scoring**
+
+`ScoringService` is the single place that decides what counts. The calendar's per-day figures and the profile's 30-day figures are both `ScoreBreakdown`s over different date ranges, so the two cannot drift apart the way two hand-written formulas did.
+
+- **Sessions** earn time scaled by focus, so a long average session can never be worth less than a short self-flattered one
+- **Achieved goal attempts** earn a flat amount — session points already pay for the effort, this pays for the outcome
+- **Completed tasks** earn timeliness only. A flat completion bonus would double-count the sessions and goals that finished the task; whether it landed before its deadline is information nothing else captures. Rescheduling costs points, so "on time" cannot be bought by moving the date
+- Stored `points_earned` is treated as **derived** — see Schema Migrations below
+
+### **Off Days**
+
+Days marked off (holiday, sick day, break) are excluded from every global score and shrink the denominators rather than counting as days with no work. The study streak skips them instead of breaking. Per-day figures and the profile charts still show what actually happened on an off day — only the aggregates exclude it.
 
 ### **Future Goal Planning**
 
 Study goals can be planned for future dates:
 
-- `StudyService.getStudyGoalsForFutureDate(date)` returns goals for a specific future date without delay processing
+- `StudyService.getGoalsForDate(date)` is the single definition shared by scoring and display, so a day's goal count always matches the list rendered beside it. Future dates skip the overdue sweep — an attempt planned for tomorrow cannot be overdue
 - The Study Planner's "Add Goal" dialog includes a DatePicker (today + future only) with quick "Today" / "Tomorrow" buttons
 - Calendar and Daily views branch on past/today/future when loading goals
 
 ### **Delayed Goal Processing Guard**
 
-`processAllDelayedGoals()` performs a full table scan and write operations. To avoid redundant work on every UI refresh, a `lastDelayProcessingDate` field ensures it runs at most once per calendar day.
+`processAllDelayedGoals()` performs a full table scan and write operations. To avoid redundant work on every UI refresh, a `lastDelayProcessingDate` field ensures it runs at most once per calendar day, via `StudyService.ensureOverdueAttemptsProcessed()`.
+
+The sweep saves without setting the Drive dirty flag. It is derived maintenance — every machine recomputes it on startup — so flagging it made simply opening the app look like unsaved local edits, which was enough to raise a sync conflict against a Drive copy that was genuinely ahead.
 
 ### **Schema Migrations**
 
@@ -91,4 +108,6 @@ Since `spring.sql.init.mode: always` loads `schema.sql` on every startup:
 
 - Tables use `CREATE TABLE IF NOT EXISTS` (safe for existing DBs)
 - New columns are added via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` at the bottom of `schema.sql`
+- Derived data may be recomputed on every startup, provided the computation is idempotent. Session points work this way: the SQL mirrors `StudySession.calculatePoints()` in integer arithmetic, and a test runs every input combination against both to keep them in step
+- Genuinely one-shot migrations — moving a value from one column to another — are guarded by a `schema_migrations` marker table. Without it, re-running would eat a value the user set after the migration first ran
 - This avoids data loss and supports rolling upgrades without external migration tools

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.2.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![JavaFX](https://img.shields.io/badge/JavaFX-21-blue.svg)](https://openjfx.io/)
 [![H2 Database](https://img.shields.io/badge/Database-H2-blue.svg)](https://www.h2database.com/)
-[![Version](https://img.shields.io/badge/Version-0.1.5-red.svg)](https://github.com/geokoko/StudySync/releases)
+[![Version](https://img.shields.io/badge/Version-0.1.6-red.svg)](https://github.com/geokoko/StudySync/releases)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ## Overview
@@ -19,7 +19,7 @@ StudySync is a comprehensive Study Management System built with modern Java tech
 
 Perfect for students who want to integrate their academic calendar with task management and study tracking! 📚✨
 
-> **⚠️ Beta Release**: This is version 0.1.5 under active development. Features may change, and some functionality may be incomplete. Please report issues and provide feedback!
+> **⚠️ Beta Release**: This is version 0.1.6 under active development. Features may change, and some functionality may be incomplete. Please report issues and provide feedback!
 
 ## Key Features
 
@@ -171,7 +171,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed architectural information an
 ## Data Storage
 
 * **Database**: H2 embedded database (`data/studysync.mv.db`)
-* **Schema Migrations**: Idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements in `schema.sql` ensure safe upgrades for existing databases
+* **Schema Migrations**: `schema.sql` re-runs on every startup, so statements are additive (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS`) or recompute derived data. The few genuinely one-shot migrations are guarded by a `schema_migrations` marker table so they cannot re-fire
 * **Cloud Backup (optional)**: When Drive sync is enabled, the same file is mirrored to `My Drive/StudySync/studysync.mv.db`
 * **Logs**: Application logs stored in `logs/` directory
 * **Configuration**: YAML configuration files in `src/main/resources/`

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ java {
 }
 
 group = 'com.studysync'
-version = '0.1.5'
+version = '0.1.6'
 description = 'StudySync - Personal Study and Task Management Desktop Application (Beta)'
 
 application {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 # Project Information
 project.name=StudySync
-project.version=0.1.5
+project.version=0.1.6
 project.description=Personal Study and Task Management Application
 
 # Java Configuration


### PR DESCRIPTION
Version bump and documentation refresh for 0.1.6.

## Version

`0.1.5` → `0.1.6` in `build.gradle`, `gradle.properties`, and the README badge/beta notice. Confirmed `scripts/build-release.sh` resolves `0.1.6`, so the release artifact will be `studysync-0.1.6-linux.tar.gz`.

## README

The schema-migration bullet claimed migrations are idempotent `ALTER TABLE ... ADD COLUMN` statements. That is no longer the whole story — it now describes the three kinds actually present: additive, idempotent recomputes of derived data, and one-shot moves guarded by the `schema_migrations` marker table.

## ARCHITECTURE.md

This had gone stale in ways that would actively mislead a reader:

- The service diagram listed **`ReminderService`**, deleted in #39, and never mentioned `ScoringService`.
- **Future Goal Planning** pointed at `StudyService.getStudyGoalsForFutureDate(date)` — also deleted. Replaced with `getGoalsForDate(date)` and why scoring and display share it.
- **Recurring Tasks** predated the `deadline` / `recurrence_end_date` split, so it still implied the old conflated meaning. It now states both, and that `isRecurringOccurrence()` and `taskSurfacesOn()` answer different questions — the distinction three call sites got wrong.
- **Schema Migrations** described additive-only migrations, with no mention of the derived-data recompute or the marker table.
- The **delayed-goal guard** section predated both the rename to `ensureOverdueAttemptsProcessed()` and the fix that stops the sweep flagging the database dirty.

New sections for **Scoring** and **Off Days**, the headline changes of the release, plus `OffDay` in the domain-model diagram.

## After merge

Tagging `v0.1.6` triggers `.github/workflows/release.yml`, which runs `build-release.sh` and publishes the GitHub release with generated notes and the tarball + checksum.

`./gradlew check` green, 60 tests.
