### PR TITLE
Rework daily reflections into a proper diary

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ StudySync provides comprehensive academic management with three main modules:
 * **Future Goal Planning**: Navigate to any future date and plan goals ahead via DatePicker
 * **Recurring Tasks**: Define repeating task schedules (e.g. every week on Mon/Wed/Fri)
 * **Daily Reflections**: A diary tab holding every entry you have ever written — search them, write a day at a time with autosave, or read the whole diary back as a thread of dated entries
+* **Markdown Diary Entries**: Reflections are markdown — headings, lists and tables (there is a button for those) — written as source and read rendered, and exportable as one `YYYY-MM-DD.md` file per day into any folder or Obsidian vault
 * **Progress Tracking**: Visual progress indicators and session statistics
 * **Study Analytics**: Monitor completed sessions and goal achievements
 * **Off Days / Holidays**: Mark any calendar day as an off day — it shows as a holiday in the calendar and never counts towards your global scores or breaks your study streak

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ StudySync provides comprehensive academic management with three main modules:
 * **Study Goals**: Set and manage daily study objectives with future date planning
 * **Future Goal Planning**: Navigate to any future date and plan goals ahead via DatePicker
 * **Recurring Tasks**: Define repeating task schedules (e.g. every week on Mon/Wed/Fri)
-* **Daily Reflections**: Record daily study insights and progress notes
+* **Daily Reflections**: A diary tab holding every entry you have ever written — search them, write a day at a time with autosave, or read the whole diary back as a thread of dated entries
 * **Progress Tracking**: Visual progress indicators and session statistics
 * **Study Analytics**: Monitor completed sessions and goal achievements
 * **Off Days / Holidays**: Mark any calendar day as an off day — it shows as a holiday in the calendar and never counts towards your global scores or breaks your study streak

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     
     // Jackson for JSON annotations used in entities
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // Markdown rendering for reflection entries (GFM tables included)
+    implementation 'org.commonmark:commonmark:0.21.0'
+    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.21.0'
     
     // Google OAuth 2.0 + Drive API
     implementation 'com.google.api-client:google-api-client:2.2.0'

--- a/src/main/java/com/studysync/domain/entity/DailyReflection.java
+++ b/src/main/java/com/studysync/domain/entity/DailyReflection.java
@@ -121,15 +121,21 @@ public class DailyReflection {
     
     /**
      * Save this daily reflection to the database (insert or update).
+     *
+     * <p>Merged on {@code date}, not {@code id}: a day has exactly one
+     * reflection (the column is UNIQUE), and callers that build a fresh
+     * entity for an already-written day would otherwise hit a constraint
+     * violation and lose the edit.</p>
      */
     public DailyReflection save() {
         if (jdbcTemplate == null) {
             throw new IllegalStateException("JdbcTemplate not initialized. Make sure Spring context is loaded.");
         }
-        
+
         String sql = """
-            MERGE INTO daily_reflections (id, date, overall_focus_level, what_to_change_tomorrow, 
+            MERGE INTO daily_reflections (id, date, overall_focus_level, what_to_change_tomorrow,
                                          completed_sessions, total_goals_achieved, notes, reflection_text, deserve_reward, updated_at)
+            KEY (date)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             """;
         

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -413,16 +413,19 @@ public class StudyService {
      * Writes the reflection text for a date; blank text deletes the entry.
      * Every reflection editor goes through here so an existing row keeps its
      * other fields instead of being replaced by a blank entity.
+     *
+     * <p>The text is stored exactly as written — reflections are markdown, and
+     * leading whitespace is significant there (indented code blocks, nested
+     * list items), so blankness decides deletion but never rewrites the text.</p>
      */
     public void saveReflectionText(LocalDate date, String text) {
-        String trimmed = text == null ? "" : text.trim();
-        if (trimmed.isEmpty()) {
+        if (text == null || text.isBlank()) {
             deleteDailyReflection(date);
             return;
         }
         DailyReflection reflection = DailyReflection.findByDate(date).orElseGet(DailyReflection::new);
         reflection.setDate(date);
-        reflection.setReflectionText(trimmed);
+        reflection.setReflectionText(text);
         addDailyReflection(reflection);
     }
 

--- a/src/main/java/com/studysync/domain/service/StudyService.java
+++ b/src/main/java/com/studysync/domain/service/StudyService.java
@@ -403,6 +403,29 @@ public class StudyService {
         return DailyReflection.findRecent(days);
     }
 
+    /** Every reflection ever written, most recent first. */
+    @Transactional(readOnly = true)
+    public List<DailyReflection> getAllDailyReflections() {
+        return DailyReflection.findAll();
+    }
+
+    /**
+     * Writes the reflection text for a date; blank text deletes the entry.
+     * Every reflection editor goes through here so an existing row keeps its
+     * other fields instead of being replaced by a blank entity.
+     */
+    public void saveReflectionText(LocalDate date, String text) {
+        String trimmed = text == null ? "" : text.trim();
+        if (trimmed.isEmpty()) {
+            deleteDailyReflection(date);
+            return;
+        }
+        DailyReflection reflection = DailyReflection.findByDate(date).orElseGet(DailyReflection::new);
+        reflection.setDate(date);
+        reflection.setReflectionText(trimmed);
+        addDailyReflection(reflection);
+    }
+
     public void deleteDailyReflection(LocalDate date) {
         boolean deleted = DailyReflection.deleteByDate(date);
         if (deleted) {

--- a/src/main/java/com/studysync/presentation/ui/components/Markdown.java
+++ b/src/main/java/com/studysync/presentation/ui/components/Markdown.java
@@ -1,0 +1,133 @@
+package com.studysync.presentation.ui.components;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+
+import java.util.List;
+
+/**
+ * Markdown for reflection entries: entries are stored as plain markdown text
+ * and rendered for reading, the way a note in Obsidian would be.
+ */
+final class Markdown {
+
+    private static final List<Extension> EXTENSIONS = List.of(TablesExtension.create());
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    /**
+     * Entry text is rendered into a JavaScript-enabled document holding every
+     * other entry, so raw HTML in an entry is escaped rather than executed and
+     * link URLs are sanitised — an entry that arrived over Drive sync is not
+     * trusted markup.
+     */
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder()
+            .extensions(EXTENSIONS)
+            .escapeHtml(true)
+            .sanitizeUrls(true)
+            .build();
+
+    /**
+     * Keeps the view on the diary: the generated date links do their own work
+     * through {@code onclick}, and every other link is inert rather than
+     * navigating this WebView onto a page that would inherit the Java bridge.
+     */
+    private static final String NO_NAVIGATION = """
+            <script>
+            document.addEventListener('click', function (e) {
+              var node = e.target;
+              while (node && node.tagName !== 'A') { node = node.parentNode; }
+              if (!node) { return; }
+              var href = node.getAttribute('href') || '';
+              if (href.charAt(0) === '#') { return; }
+              e.preventDefault();
+            }, true);
+            </script>
+            """;
+
+    private static final String STYLE = """
+            body { font-family: Georgia, 'Times New Roman', serif; font-size: 14px;
+                   color: #2c3e50; line-height: 1.6; margin: 0; padding: 4px 18px 24px 4px;
+                   background: transparent; }
+            h1, h2, h3, h4 { font-family: Roboto, sans-serif; color: #2c3e50; }
+            article { margin-bottom: 4px; }
+            article > h2 { font-size: 14px; margin: 0 0 6px 0; }
+            article > h2 a { color: #3498db; text-decoration: none; }
+            article > h2 a:hover { text-decoration: underline; }
+            article > :nth-child(2) { margin-top: 0; }
+            hr { border: 0; border-top: 1px solid #ecf0f1; margin: 22px 0; }
+            table { border-collapse: collapse; margin: 12px 0; }
+            th, td { border: 1px solid #dfe4e8; padding: 5px 10px; text-align: left; }
+            th { background: #f8f9fa; font-family: Roboto, sans-serif; font-size: 13px; }
+            blockquote { border-left: 3px solid #dfe4e8; margin-left: 0; padding-left: 14px;
+                         color: #7f8c8d; }
+            code { background: #f4f6f8; padding: 1px 4px; border-radius: 3px;
+                   font-size: 13px; }
+            pre code { display: block; padding: 8px 10px; overflow-x: auto; }
+            img { max-width: 100%; }
+            .empty { color: #7f8c8d; font-style: italic; }
+            """;
+
+    private Markdown() { /* utility class */ }
+
+    /** Renders one entry's markdown to an HTML fragment. */
+    static String toHtml(String markdown) {
+        if (markdown == null || markdown.isBlank()) {
+            return "";
+        }
+        return RENDERER.render(PARSER.parse(markdown));
+    }
+
+    /** Wraps rendered entries in the styled document the diary's reading view loads. */
+    static String page(String bodyHtml) {
+        return "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>"
+                + STYLE + "</style></head><body>" + bodyHtml + NO_NAVIGATION + "</body></html>";
+    }
+
+    /**
+     * A GitHub-flavoured table skeleton: placeholder headers and two empty
+     * rows, padded so the source stays readable while it is being filled in.
+     */
+    static String tableSkeleton(int columns) {
+        int cols = Math.max(1, columns);
+        StringBuilder md = new StringBuilder("\n");
+        for (int c = 1; c <= cols; c++) {
+            md.append("| Column ").append(c).append(' ');
+        }
+        md.append("|\n");
+        for (int c = 1; c <= cols; c++) {
+            md.append("| --- ");
+        }
+        md.append("|\n");
+        for (int row = 0; row < 2; row++) {
+            md.append("|     ".repeat(cols)).append("|\n");
+        }
+        return md.toString();
+    }
+
+    /**
+     * The first line worth putting in a list: heading markers and inline
+     * emphasis are stripped, table rules and quote markers skipped, so an
+     * entry that opens with a table still shows something readable.
+     */
+    static String previewLine(String markdown) {
+        if (markdown == null) {
+            return "";
+        }
+        for (String line : markdown.split("\\R")) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith(">") || trimmed.startsWith("|")
+                    || trimmed.startsWith("---") || trimmed.startsWith("```")) {
+                continue;
+            }
+            return trimmed.replaceAll("^#+\\s*", "").replaceAll("[*_`]", "").trim();
+        }
+        // Nothing but tables or quotes — fall back to the first non-empty line.
+        for (String line : markdown.split("\\R")) {
+            if (!line.isBlank()) {
+                return line.trim();
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/studysync/presentation/ui/components/ReflectionDiaryPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ReflectionDiaryPanel.java
@@ -1,329 +1,416 @@
 package com.studysync.presentation.ui.components;
 
-import com.studysync.domain.service.StudyService;
-import com.studysync.domain.service.DateTimeService;
 import com.studysync.domain.entity.DailyReflection;
+import com.studysync.domain.service.DateTimeService;
+import com.studysync.domain.service.StudyService;
+import javafx.animation.PauseTransition;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.Node;
 import javafx.scene.control.*;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
-import javafx.scene.Node;
+import javafx.util.Duration;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
+import java.util.Locale;
 
 /**
- * A diary-like interface for viewing and managing daily reflections.
- * Allows easy navigation between different dates and reflection entries.
+ * The diary: every past reflection in one browsable, searchable list on the
+ * left; on the right either one day open for writing, or the whole diary as a
+ * scrolling thread of dated entries.
+ *
+ * <p>Entries save themselves — a short pause in typing, leaving the editor,
+ * or moving to another day all flush the text. Clearing an entry deletes it.</p>
  */
-public class ReflectionDiaryPanel extends ScrollPane implements RefreshablePanel {
+public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel {
+
+    private static final DateTimeFormatter HEADER_FORMAT =
+            DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy");
+    private static final DateTimeFormatter LIST_FORMAT =
+            DateTimeFormatter.ofPattern("EEE, d MMM yyyy");
+    private static final DateTimeFormatter SAVED_AT_FORMAT =
+            DateTimeFormatter.ofPattern("HH:mm");
+
     private final StudyService studyService;
     private final DateTimeService dateTimeService;
-    
-    // UI Components
-    private DatePicker datePicker;
-    private TextArea reflectionTextArea;
-    private VBox reflectionContent;
-    private Label dateHeaderLabel;
-    private Button saveButton;
-    private ListView<LocalDate> recentReflectionsList;
-    
+
+    private final ObservableList<DailyReflection> entries = FXCollections.observableArrayList();
+    private final FilteredList<DailyReflection> matches = new FilteredList<>(entries);
+    private final ListView<DailyReflection> entryList = new ListView<>(matches);
+    private final TextField searchField = new TextField();
+    private final Label entryCount = new Label();
+    private final DatePicker datePicker = new DatePicker();
+    private final Label dateHeader = new Label();
+    private final TextArea editor = new TextArea();
+    private final Label wordCount = new Label();
+    private final Label status = new Label();
+    private final ScrollPane feed = new ScrollPane();
+    private final ToggleButton writeToggle = new ToggleButton("Write");
+    private final ToggleButton readToggle = new ToggleButton("Read");
+    private final PauseTransition autosave = new PauseTransition(Duration.seconds(1.5));
+
+    private LocalDate openDate;
+    /** Text currently persisted for {@link #openDate}; the editor is dirty when it differs. */
+    private String savedText = "";
+    /** Set while the editor is being populated, so that doesn't count as typing. */
+    private boolean populating;
+
     public ReflectionDiaryPanel(StudyService studyService, DateTimeService dateTimeService) {
         this.studyService = studyService;
         this.dateTimeService = dateTimeService;
-        
-        // Create main content container
-        VBox mainContent = new VBox(20);
-        mainContent.setPadding(new Insets(20));
-        mainContent.getStyleClass().add("panel-bg-warm");
-        
-        // Set up ScrollPane properties
-        this.setContent(mainContent);
-        this.setFitToWidth(true);
-        this.setFitToHeight(false);
-        this.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        this.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        this.getStyleClass().add("tab-content-area");
-        
-        initializeComponents(mainContent);
-        updateDisplay();
-        
-        // Register for date change notifications
+        this.openDate = dateTimeService.getCurrentDate();
+
+        getStyleClass().addAll("tab-content-area", "panel-bg-warm");
+        setPadding(new Insets(20));
+        setLeft(buildSidebar());
+        setCenter(buildEditor());
+        BorderPane.setMargin(getCenter(), new Insets(0, 0, 0, 20));
+
+        autosave.setOnFinished(e -> flush());
         dateTimeService.addDateChangeListener(this::onDateChanged);
+
+        reloadEntries();
+        open(openDate);
     }
 
-    private void initializeComponents(VBox mainContent) {
-        // Header
-        Label headerLabel = new Label("Daily Reflection Diary");
-        headerLabel.setGraphic(TaskStyleUtils.iconLabel("\u270E", 24));
-        TaskStyleUtils.fontBold(headerLabel, 24);
-        
-        // Create main layout with sidebar and content
-        HBox mainLayout = new HBox(20);
-        mainLayout.setPrefHeight(600);
-        
-        // Left sidebar for navigation
-        VBox sidebar = createSidebar();
-        sidebar.setPrefWidth(250);
-        sidebar.setMaxWidth(250);
-        
-        // Right content area
-        VBox contentArea = createContentArea();
-        HBox.setHgrow(contentArea, Priority.ALWAYS);
-        
-        mainLayout.getChildren().addAll(sidebar, contentArea);
-        
-        mainContent.getChildren().addAll(headerLabel, mainLayout);
-    }
-    
-    private VBox createSidebar() {
-        VBox sidebar = new VBox(15);
+    // ── Layout ──────────────────────────────────────────────────
+
+    private VBox buildSidebar() {
+        VBox sidebar = new VBox(12);
         sidebar.getStyleClass().add("section-card");
         sidebar.setPadding(new Insets(15));
-        
-        Label sidebarTitle = new Label("» Navigation");
-        TaskStyleUtils.fontBold(sidebarTitle, 16);
-        
-        // Date picker for navigation
-        Label dateLabel = new Label("Select Date:");
-        TaskStyleUtils.fontSemiBold(dateLabel, 12);
-        
-        datePicker = new DatePicker(dateTimeService.getCurrentDate());
-        datePicker.setMaxWidth(Double.MAX_VALUE);
-        datePicker.setOnAction(e -> loadReflectionForDate(datePicker.getValue()));
-        
-        // Quick navigation buttons
-        VBox quickNav = new VBox(5);
-        Button todayBtn = new Button("Today");
-        todayBtn.setMaxWidth(Double.MAX_VALUE);
-        todayBtn.getStyleClass().add("btn-primary");
-        todayBtn.setOnAction(e -> navigateToDate(dateTimeService.getCurrentDate()));
-        
-        Button yesterdayBtn = new Button("Yesterday");
-        yesterdayBtn.setMaxWidth(Double.MAX_VALUE);
-        yesterdayBtn.getStyleClass().add("btn-purple");
-        yesterdayBtn.setOnAction(e -> navigateToDate(dateTimeService.getCurrentDate().minusDays(1)));
-        
-        Button lastWeekBtn = new Button("One Week Ago");
-        lastWeekBtn.setMaxWidth(Double.MAX_VALUE);
-        lastWeekBtn.getStyleClass().add("btn-orange");
-        lastWeekBtn.setOnAction(e -> navigateToDate(dateTimeService.getCurrentDate().minusDays(7)));
-        
-        quickNav.getChildren().addAll(todayBtn, yesterdayBtn, lastWeekBtn);
-        
-        // Recent reflections list
-        Label recentLabel = new Label("Recent Reflections:");
-        TaskStyleUtils.fontSemiBold(recentLabel, 12);
-        
-        recentReflectionsList = new ListView<>();
-        recentReflectionsList.setPrefHeight(200);
-        recentReflectionsList.setCellFactory(param -> new ListCell<LocalDate>() {
-            @Override
-            protected void updateItem(LocalDate item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    String dateText = item.format(DateTimeFormatter.ofPattern("MMM dd, yyyy"));
-                    if (item.equals(dateTimeService.getCurrentDate())) {
-                        dateText += " (Today)";
-                    } else if (item.equals(dateTimeService.getCurrentDate().minusDays(1))) {
-                        dateText += " (Yesterday)";
-                    }
-                    setText(dateText);
-                }
+        sidebar.setPrefWidth(300);
+        sidebar.setMinWidth(300);
+
+        Label title = new Label("Diary");
+        title.setGraphic(TaskStyleUtils.iconLabel("✎", 20));
+        TaskStyleUtils.fontBold(title, 20);
+
+        searchField.setPromptText("Search entries…");
+        searchField.textProperty().addListener((obs, old, text) -> applyFilter(text));
+
+        TaskStyleUtils.fontNormal(entryCount, 11);
+        entryCount.setTextFill(Color.web(TaskStyleUtils.COLOR_MUTED));
+
+        entryList.setCellFactory(view -> new EntryCell());
+        entryList.setPlaceholder(new Label("No reflections yet."));
+        entryList.getSelectionModel().selectedItemProperty().addListener((obs, old, entry) -> {
+            if (entry != null && !entry.getDate().equals(openDate)) {
+                goTo(entry.getDate());
             }
         });
-        recentReflectionsList.setOnMouseClicked(e -> {
-            LocalDate selectedDate = recentReflectionsList.getSelectionModel().getSelectedItem();
-            if (selectedDate != null) {
-                navigateToDate(selectedDate);
-            }
-        });
-        
-        loadRecentReflections();
-        
-        sidebar.getChildren().addAll(
-            sidebarTitle,
-            new Separator(),
-            dateLabel, datePicker,
-            new Label("Quick Navigation:"), quickNav,
-            new Separator(),
-            recentLabel, recentReflectionsList
-        );
-        
+        VBox.setVgrow(entryList, Priority.ALWAYS);
+
+        sidebar.getChildren().addAll(title, searchField, entryCount, entryList);
         return sidebar;
     }
-    
-    private VBox createContentArea() {
-        VBox contentArea = new VBox(15);
-        contentArea.getStyleClass().add("section-card");
-        
-        // Date header
-        dateHeaderLabel = new Label();
-        TaskStyleUtils.fontBold(dateHeaderLabel, 18);
-        
-        // Reflection text area
-        Label reflectionLabel = new Label("Daily Reflection:");
-        reflectionLabel.setGraphic(TaskStyleUtils.iconLabel("\u2605", 14));
-        TaskStyleUtils.fontSemiBold(reflectionLabel, 14);
-        
-        reflectionTextArea = new TextArea();
-        reflectionTextArea.setPromptText("Write your daily reflection here...\n\nSome questions to consider:\n• What went well today?\n• What challenges did you face?\n• What did you learn?\n• What would you do differently?\n• How do you feel about your progress?");
-        reflectionTextArea.setPrefRowCount(15);
-        reflectionTextArea.setWrapText(true);
-        reflectionTextArea.setStyle("-fx-font-family: 'Georgia', 'Times New Roman', serif; -fx-font-size: 13px; -fx-line-spacing: 1.2em;");
-        
-        // Save button
-        HBox buttonBox = new HBox(10);
-        buttonBox.setAlignment(Pos.CENTER_RIGHT);
-        
-        saveButton = new Button("Save Reflection");
-        saveButton.setGraphic(TaskStyleUtils.iconLabel("\u2713", 12));
-        saveButton.getStyleClass().add("btn-success");
-        saveButton.setOnAction(e -> saveCurrentReflection());
-        
-        Button newReflectionBtn = new Button("New Entry");
-        newReflectionBtn.setGraphic(TaskStyleUtils.iconLabel("\u25AA", 12));
-        newReflectionBtn.getStyleClass().add("btn-primary");
-        newReflectionBtn.setOnAction(e -> createNewReflection());
-        
-        buttonBox.getChildren().addAll(newReflectionBtn, saveButton);
-        
-        reflectionContent = new VBox(10);
-        reflectionContent.getChildren().addAll(dateHeaderLabel, reflectionLabel, reflectionTextArea, buttonBox);
-        
-        contentArea.getChildren().add(reflectionContent);
-        
-        return contentArea;
+
+    private VBox buildEditor() {
+        VBox pane = new VBox(12);
+        pane.getStyleClass().add("section-card");
+        pane.setPadding(new Insets(20));
+
+        Button prev = new Button();
+        prev.setGraphic(TaskStyleUtils.iconLabel("◀", 12));
+        prev.getStyleClass().add("btn-primary");
+        prev.setOnAction(e -> goTo(openDate.minusDays(1)));
+
+        Button next = new Button();
+        next.setGraphic(TaskStyleUtils.iconLabel("▶", 12));
+        next.getStyleClass().add("btn-primary");
+        next.setOnAction(e -> goTo(openDate.plusDays(1)));
+
+        Button today = new Button("Today");
+        today.getStyleClass().add("btn-purple");
+        today.setOnAction(e -> goTo(dateTimeService.getCurrentDate()));
+
+        TaskStyleUtils.fontBold(dateHeader, 18);
+
+        datePicker.setOnAction(e -> {
+            LocalDate picked = datePicker.getValue();
+            if (picked != null && !picked.equals(openDate)) {
+                goTo(picked);
+            }
+        });
+
+        ToggleGroup modes = new ToggleGroup();
+        writeToggle.setToggleGroup(modes);
+        readToggle.setToggleGroup(modes);
+        writeToggle.setSelected(true);
+        modes.selectedToggleProperty().addListener((obs, old, selected) -> {
+            if (selected == null) {
+                old.setSelected(true); // never leave both off
+                return;
+            }
+            showFeed(selected == readToggle);
+        });
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox header = new HBox(10, prev, next, dateHeader, spacer,
+                writeToggle, readToggle, datePicker, today);
+        header.setAlignment(Pos.CENTER_LEFT);
+
+        editor.setPromptText("""
+                How did today go?
+
+                • What went well?
+                • What got in the way?
+                • What did you learn?
+                • What would you do differently tomorrow?""");
+        editor.setWrapText(true);
+        editor.setStyle("-fx-font-family: 'Georgia', 'Times New Roman', serif; "
+                + "-fx-font-size: 14px; -fx-line-spacing: 0.35em;");
+        editor.textProperty().addListener((obs, old, text) -> {
+            updateWordCount(text);
+            if (populating) return;
+            status.setText("Unsaved…");
+            status.setTextFill(Color.web(TaskStyleUtils.COLOR_ORANGE));
+            autosave.playFromStart();
+        });
+        editor.focusedProperty().addListener((obs, was, focused) -> {
+            if (!focused) flush();
+        });
+        editor.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+            if (new KeyCodeCombination(KeyCode.S, KeyCombination.SHORTCUT_DOWN).match(e)) {
+                flush();
+                e.consume();
+            }
+        });
+        feed.setFitToWidth(true);
+        feed.getStyleClass().add("section-card-flat");
+        feed.setVisible(false);
+        feed.setManaged(false);
+
+        StackPane body = new StackPane(editor, feed);
+        VBox.setVgrow(body, Priority.ALWAYS);
+
+        TaskStyleUtils.fontNormal(wordCount, 11);
+        wordCount.setTextFill(Color.web(TaskStyleUtils.COLOR_MUTED));
+        TaskStyleUtils.fontNormal(status, 11);
+
+        Region footSpacer = new Region();
+        HBox.setHgrow(footSpacer, Priority.ALWAYS);
+        HBox footer = new HBox(10, wordCount, footSpacer, status);
+        footer.setAlignment(Pos.CENTER_LEFT);
+
+        pane.getChildren().addAll(header, body, footer);
+        return pane;
     }
-    
-    private void navigateToDate(LocalDate date) {
+
+    // ── Behaviour ───────────────────────────────────────────────
+
+    /** Navigating to a specific day means writing in it — reading is the thread. */
+    private void goTo(LocalDate date) {
+        open(date);
+        writeToggle.setSelected(true);
+        editor.requestFocus();
+    }
+
+    /** Flushes the open entry, then swaps the editor over to {@code date}. */
+    private void open(LocalDate date) {
+        flush();
+        openDate = date;
+
+        String text = studyService.getDailyReflectionForDate(date)
+                .map(DailyReflection::getReflectionText)
+                .orElse("");
+        savedText = text == null ? "" : text;
+
+        populating = true;
+        editor.setText(savedText);
+        populating = false;
+
+        dateHeader.setText(describe(date));
         datePicker.setValue(date);
-        loadReflectionForDate(date);
+        updateWordCount(savedText);
+        status.setText("");
+        syncSelection();
     }
-    
-    private void loadReflectionForDate(LocalDate date) {
-        if (date == null) {
-            date = dateTimeService.getCurrentDate();
-        }
-        
-        // Update header
-        String dateStr = date.format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"));
-        if (date.equals(dateTimeService.getCurrentDate())) {
-            dateStr += " (Today)";
-        } else if (date.equals(dateTimeService.getCurrentDate().minusDays(1))) {
-            dateStr += " (Yesterday)";
-        }
-        dateHeaderLabel.setText("» " + dateStr);
-        
-        // Load reflection for the date
+
+    /** Persists the editor's text when it differs from what is stored. */
+    private void flush() {
+        autosave.stop();
+        if (openDate == null) return;
+
+        String text = editor.getText() == null ? "" : editor.getText().trim();
+        if (text.equals(savedText.trim())) return;
+
         try {
-            Optional<DailyReflection> reflectionOpt = DailyReflection.findByDate(date);
-            if (reflectionOpt.isPresent()) {
-                DailyReflection reflection = reflectionOpt.get();
-                reflectionTextArea.setText(reflection.getReflectionText() != null ? reflection.getReflectionText() : "");
-                saveButton.setText("Update Reflection");
-            } else {
-                reflectionTextArea.setText("");
-                saveButton.setText("Save Reflection");
-            }
-        } catch (Exception e) {
-            reflectionTextArea.setText("");
-            System.err.println("Error loading reflection for " + date + ": " + e.getMessage());
+            studyService.saveReflectionText(openDate, text);
+            savedText = text;
+            status.setText(text.isEmpty()
+                    ? "Entry deleted"
+                    : "Saved " + LocalTime.now().format(SAVED_AT_FORMAT));
+            status.setTextFill(Color.web(TaskStyleUtils.COLOR_SUCCESS));
+            reloadEntries();
+        } catch (Exception ex) {
+            status.setText("Not saved: " + ex.getMessage());
+            status.setTextFill(Color.web(TaskStyleUtils.COLOR_DANGER));
         }
-        
-        // Update recent reflections list to highlight current selection
-        loadRecentReflections();
     }
-    
-    private void loadRecentReflections() {
+
+    private void reloadEntries() {
         try {
-            List<DailyReflection> recentReflections = DailyReflection.findRecent(30); // Last 30 days
-            recentReflectionsList.getItems().clear();
-            
-            for (DailyReflection reflection : recentReflections) {
-                recentReflectionsList.getItems().add(reflection.getDate());
-            }
-            
-            // Highlight current date if it exists
-            LocalDate currentDate = datePicker.getValue();
-            if (currentDate != null && recentReflectionsList.getItems().contains(currentDate)) {
-                recentReflectionsList.getSelectionModel().select(currentDate);
-            }
-        } catch (Exception e) {
-            System.err.println("Error loading recent reflections: " + e.getMessage());
+            List<DailyReflection> all = studyService.getAllDailyReflections();
+            entries.setAll(all);
+            entryCount.setText(all.size() == 1 ? "1 entry" : all.size() + " entries");
+            syncSelection();
+            if (feed.isVisible()) renderFeed();
+        } catch (Exception ex) {
+            entryCount.setText("Unable to load entries: " + ex.getMessage());
         }
     }
-    
-    private void saveCurrentReflection() {
-        LocalDate selectedDate = datePicker.getValue();
-        if (selectedDate == null) {
-            selectedDate = dateTimeService.getCurrentDate();
+
+    /** Swaps the right-hand pane between the day editor and the reading thread. */
+    private void showFeed(boolean reading) {
+        if (reading) {
+            flush();
+            renderFeed();
         }
-        
-        String reflectionText = reflectionTextArea.getText().trim();
-        
-        try {
-            Optional<DailyReflection> existingOpt = DailyReflection.findByDate(selectedDate);
-            DailyReflection reflection;
-            
-            if (existingOpt.isPresent()) {
-                reflection = existingOpt.get();
-                reflection.setReflectionText(reflectionText);
-            } else {
-                reflection = new DailyReflection();
-                reflection.setDate(selectedDate);
-                reflection.setReflectionText(reflectionText);
+        feed.setVisible(reading);
+        feed.setManaged(reading);
+        editor.setVisible(!reading);
+        editor.setManaged(!reading);
+        wordCount.setVisible(!reading);
+    }
+
+    /**
+     * Renders every entry that survives the current search as one dated card,
+     * newest first — the diary read back as a thread.
+     */
+    private void renderFeed() {
+        VBox thread = new VBox(16);
+        thread.setPadding(new Insets(4, 16, 12, 4));
+
+        // ponytail: builds a card per entry, no virtualisation. Move to a
+        // ListView with a wrapping cell if a few thousand entries ever lag.
+        for (DailyReflection entry : matches) {
+            thread.getChildren().add(feedCard(entry));
+        }
+        if (thread.getChildren().isEmpty()) {
+            Label empty = new Label(searchField.getText() == null || searchField.getText().isBlank()
+                    ? "Nothing written yet — switch to Write and start today's entry."
+                    : "No entries match that search.");
+            TaskStyleUtils.fontItalic(empty, 12);
+            empty.setTextFill(Color.web(TaskStyleUtils.COLOR_MUTED));
+            thread.getChildren().add(empty);
+        }
+        feed.setContent(thread);
+    }
+
+    /** One entry in the thread: its date, its text, and a click to go edit it. */
+    private VBox feedCard(DailyReflection entry) {
+        Label when = new Label(describe(entry.getDate()));
+        TaskStyleUtils.fontSemiBold(when, 13);
+        when.setTextFill(Color.web(TaskStyleUtils.COLOR_PRIMARY));
+
+        Label text = new Label(entry.getReflectionText() == null ? "" : entry.getReflectionText());
+        text.setWrapText(true);
+        text.setStyle("-fx-font-family: 'Georgia', 'Times New Roman', serif; "
+                + "-fx-font-size: 13px; -fx-line-spacing: 0.3em;");
+
+        VBox card = new VBox(6, when, text);
+        card.getStyleClass().add("section-card-light");
+        card.setPadding(new Insets(12, 14, 12, 14));
+        card.setCursor(Cursor.HAND);
+        Tooltip.install(card, new Tooltip("Open this day for editing"));
+        card.setOnMouseClicked(e -> goTo(entry.getDate()));
+        return card;
+    }
+
+    private void applyFilter(String query) {
+        String needle = query == null ? "" : query.trim().toLowerCase(Locale.ROOT);
+        matches.setPredicate(needle.isEmpty() ? null : entry -> {
+            String text = entry.getReflectionText();
+            return (text != null && text.toLowerCase(Locale.ROOT).contains(needle))
+                    || entry.getDate().format(LIST_FORMAT).toLowerCase(Locale.ROOT).contains(needle);
+        });
+        syncSelection();
+        if (feed.isVisible()) renderFeed();
+    }
+
+    /** Highlights the open day in the list without re-triggering navigation. */
+    private void syncSelection() {
+        for (DailyReflection entry : matches) {
+            if (entry.getDate().equals(openDate)) {
+                entryList.getSelectionModel().select(entry);
+                return;
             }
-            
-            studyService.addDailyReflection(reflection);
-            
-            // Show success message
-            Alert success = new Alert(Alert.AlertType.INFORMATION);
-            success.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
-            success.setTitle("Success");
-            success.setHeaderText(null);
-            success.setContentText("Reflection saved successfully for " + selectedDate.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")));
-            success.showAndWait();
-            
-            // Refresh recent reflections
-            loadRecentReflections();
-            
-        } catch (Exception e) {
-            Alert error = new Alert(Alert.AlertType.ERROR);
-            error.initOwner(this.getScene() != null ? this.getScene().getWindow() : null);
-            error.setTitle("Error");
-            error.setHeaderText(null);
-            error.setContentText("Failed to save reflection: " + e.getMessage());
-            error.showAndWait();
         }
+        entryList.getSelectionModel().clearSelection();
     }
-    
-    private void createNewReflection() {
-        navigateToDate(dateTimeService.getCurrentDate());
-        reflectionTextArea.clear();
-        reflectionTextArea.requestFocus();
+
+    private void updateWordCount(String text) {
+        int words = (text == null || text.isBlank()) ? 0 : text.trim().split("\\s+").length;
+        wordCount.setText(words == 1 ? "1 word" : words + " words");
     }
-    
+
+    private String describe(LocalDate date) {
+        return date.format(HEADER_FORMAT) + relativeSuffix(date);
+    }
+
+    private String relativeSuffix(LocalDate date) {
+        LocalDate today = dateTimeService.getCurrentDate();
+        if (date.equals(today)) return " · Today";
+        if (date.equals(today.minusDays(1))) return " · Yesterday";
+        return "";
+    }
+
     private void onDateChanged(LocalDate newDate) {
-        // Auto-navigate to the new date if currently viewing yesterday
-        LocalDate pickerValue = datePicker.getValue();
-        if (pickerValue != null && pickerValue.equals(dateTimeService.getCurrentDate().minusDays(1))) {
-            navigateToDate(newDate);
-        }
+        // Midnight rollover: keep "Today"/"Yesterday" labels honest.
+        dateHeader.setText(describe(openDate));
+        entryList.refresh();
     }
-    
+
     @Override
     public void updateDisplay() {
-        loadReflectionForDate(datePicker.getValue());
+        reloadEntries();
+        if (editor.getText() != null && editor.getText().trim().equals(savedText.trim())) {
+            open(openDate);
+        }
     }
-    
+
     @Override
     public Node getView() {
         return this;
+    }
+
+    /** Date line plus a one-line preview, so the list reads like a diary index. */
+    private final class EntryCell extends ListCell<DailyReflection> {
+        @Override
+        protected void updateItem(DailyReflection entry, boolean empty) {
+            super.updateItem(entry, empty);
+            if (empty || entry == null) {
+                setText(null);
+                setGraphic(null);
+                return;
+            }
+
+            Label date = new Label(entry.getDate().format(LIST_FORMAT) + relativeSuffix(entry.getDate()));
+            TaskStyleUtils.fontSemiBold(date, 12);
+
+            String text = entry.getReflectionText() == null ? "" : entry.getReflectionText().replaceAll("\\s+", " ").trim();
+            Label preview = new Label(text.length() > 70 ? text.substring(0, 70) + "…" : text);
+            TaskStyleUtils.fontNormal(preview, 11);
+            preview.setTextFill(Color.web(TaskStyleUtils.COLOR_MUTED));
+
+            VBox box = new VBox(2, date, preview);
+            box.setPadding(new Insets(4, 0, 4, 0));
+            setText(null);
+            setGraphic(box);
+        }
     }
 }

--- a/src/main/java/com/studysync/presentation/ui/components/ReflectionDiaryPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/ReflectionDiaryPanel.java
@@ -4,32 +4,58 @@ import com.studysync.domain.entity.DailyReflection;
 import com.studysync.domain.service.DateTimeService;
 import com.studysync.domain.service.StudyService;
 import javafx.animation.PauseTransition;
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.concurrent.Worker;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Cursor;
 import javafx.scene.Node;
-import javafx.scene.control.*;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
+import javafx.scene.web.WebView;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
 import javafx.util.Duration;
+import netscape.javascript.JSObject;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
 /**
  * The diary: every past reflection in one browsable, searchable list on the
- * left; on the right either one day open for writing, or the whole diary as a
- * scrolling thread of dated entries.
+ * left; on the right either one day open for writing, or the whole diary
+ * rendered as a scrolling thread of dated entries.
+ *
+ * <p>Entries are markdown — tables included — written as source in the editor
+ * and read rendered, the way a note in Obsidian works. They can be exported as
+ * one {@code YYYY-MM-DD.md} file per day.</p>
  *
  * <p>Entries save themselves — a short pause in typing, leaving the editor,
  * or moving to another day all flush the text. Clearing an entry deletes it.</p>
@@ -42,6 +68,8 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
             DateTimeFormatter.ofPattern("EEE, d MMM yyyy");
     private static final DateTimeFormatter SAVED_AT_FORMAT =
             DateTimeFormatter.ofPattern("HH:mm");
+    /** Column counts offered by the "Table" button. */
+    private static final int[] TABLE_COLUMNS = {2, 3, 4, 5, 6};
 
     private final StudyService studyService;
     private final DateTimeService dateTimeService;
@@ -56,10 +84,12 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
     private final TextArea editor = new TextArea();
     private final Label wordCount = new Label();
     private final Label status = new Label();
-    private final ScrollPane feed = new ScrollPane();
+    private final WebView feed = new WebView();
     private final ToggleButton writeToggle = new ToggleButton("Write");
     private final ToggleButton readToggle = new ToggleButton("Read");
     private final PauseTransition autosave = new PauseTransition(Duration.seconds(1.5));
+    /** Held in a field: {@code JSObject.setMember} does not keep the bridge alive. */
+    private final DiaryBridge bridge = new DiaryBridge();
 
     private LocalDate openDate;
     /** Text currently persisted for {@link #openDate}; the editor is dirty when it differs. */
@@ -157,19 +187,46 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
             showFeed(selected == readToggle);
         });
 
+        MenuButton tableButton = new MenuButton("Table");
+        tableButton.setGraphic(TaskStyleUtils.iconLabel("▦", 12));
+        tableButton.getStyleClass().add("btn-primary");
+        for (int columns : TABLE_COLUMNS) {
+            MenuItem item = new MenuItem(columns + " columns");
+            int cols = columns;
+            item.setOnAction(e -> insertTable(cols));
+            tableButton.getItems().add(item);
+        }
+        tableButton.disableProperty().bind(readToggle.selectedProperty());
+
+        MenuButton exportButton = new MenuButton("Export");
+        exportButton.setGraphic(TaskStyleUtils.iconLabel("⇩", 12));
+        exportButton.getStyleClass().add("btn-purple");
+        MenuItem exportOne = new MenuItem("This entry…");
+        exportOne.setOnAction(e -> exportEntry());
+        MenuItem exportAll = new MenuItem("All shown entries…");
+        exportAll.setOnAction(e -> exportAll());
+        exportButton.getItems().addAll(exportOne, exportAll);
+
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
-        HBox header = new HBox(10, prev, next, dateHeader, spacer,
-                writeToggle, readToggle, datePicker, today);
+        HBox header = new HBox(10, prev, next, dateHeader, spacer, datePicker, today);
         header.setAlignment(Pos.CENTER_LEFT);
+
+        Region toolbarSpacer = new Region();
+        HBox.setHgrow(toolbarSpacer, Priority.ALWAYS);
+        HBox toolbar = new HBox(10, writeToggle, readToggle, toolbarSpacer, tableButton, exportButton);
+        toolbar.setAlignment(Pos.CENTER_LEFT);
 
         editor.setPromptText("""
                 How did today go?
 
-                • What went well?
-                • What got in the way?
-                • What did you learn?
-                • What would you do differently tomorrow?""");
+                - What went well?
+                - What got in the way?
+                - What did you learn?
+                - What would you do differently tomorrow?
+
+                Markdown works here: **bold**, # headings, lists, and tables
+                (the Table button drops one in). Read shows it rendered.""");
         editor.setWrapText(true);
         editor.setStyle("-fx-font-family: 'Georgia', 'Times New Roman', serif; "
                 + "-fx-font-size: 14px; -fx-line-spacing: 0.35em;");
@@ -189,10 +246,22 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
                 e.consume();
             }
         });
-        feed.setFitToWidth(true);
-        feed.getStyleClass().add("section-card-flat");
         feed.setVisible(false);
         feed.setManaged(false);
+        feed.setContextMenuEnabled(false);
+        // The rendered page calls back through window.studysync to open a day.
+        // Only the document this panel generated gets the bridge — never a page
+        // the view was navigated to.
+        feed.getEngine().getLoadWorker().stateProperty().addListener((obs, was, state) -> {
+            if (state == Worker.State.SUCCEEDED && isGeneratedPage()) {
+                try {
+                    JSObject window = (JSObject) feed.getEngine().executeScript("window");
+                    window.setMember("studysync", bridge);
+                } catch (RuntimeException ex) {
+                    // Reading still works; the sidebar remains the way in.
+                }
+            }
+        });
 
         StackPane body = new StackPane(editor, feed);
         VBox.setVgrow(body, Priority.ALWAYS);
@@ -206,11 +275,17 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
         HBox footer = new HBox(10, wordCount, footSpacer, status);
         footer.setAlignment(Pos.CENTER_LEFT);
 
-        pane.getChildren().addAll(header, body, footer);
+        pane.getChildren().addAll(header, toolbar, body, footer);
         return pane;
     }
 
     // ── Behaviour ───────────────────────────────────────────────
+
+    /** True while the view holds the document this panel built, not a remote page. */
+    private boolean isGeneratedPage() {
+        String location = feed.getEngine().getLocation();
+        return location == null || location.isEmpty() || location.startsWith("about:");
+    }
 
     /** Navigating to a specific day means writing in it — reading is the thread. */
     private void goTo(LocalDate date) {
@@ -219,9 +294,16 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
         editor.requestFocus();
     }
 
-    /** Flushes the open entry, then swaps the editor over to {@code date}. */
+    /**
+     * Flushes the open entry, then swaps the editor over to {@code date}.
+     * A failed save aborts the move, so the unsaved text stays on screen.
+     */
     private void open(LocalDate date) {
-        flush();
+        if (!flush()) {
+            datePicker.setValue(openDate);
+            syncSelection();
+            return;
+        }
         openDate = date;
 
         String text = studyService.getDailyReflectionForDate(date)
@@ -240,25 +322,30 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
         syncSelection();
     }
 
-    /** Persists the editor's text when it differs from what is stored. */
-    private void flush() {
+    /**
+     * Persists the editor's text when it differs from what is stored.
+     *
+     * @return {@code false} when the write failed — the caller must not move
+     *         off this day or act on the stored entries, the editor still
+     *         holds the only copy of the text
+     */
+    private boolean flush() {
         autosave.stop();
-        if (openDate == null) return;
+        if (openDate == null) return true;
 
-        String text = editor.getText() == null ? "" : editor.getText().trim();
-        if (text.equals(savedText.trim())) return;
+        String text = editor.getText() == null ? "" : editor.getText();
+        if (text.equals(savedText)) return true;
 
         try {
             studyService.saveReflectionText(openDate, text);
             savedText = text;
-            status.setText(text.isEmpty()
-                    ? "Entry deleted"
-                    : "Saved " + LocalTime.now().format(SAVED_AT_FORMAT));
-            status.setTextFill(Color.web(TaskStyleUtils.COLOR_SUCCESS));
+            report(text.isBlank() ? "Entry deleted" : "Saved " + LocalTime.now().format(SAVED_AT_FORMAT),
+                    TaskStyleUtils.COLOR_SUCCESS);
             reloadEntries();
+            return true;
         } catch (Exception ex) {
-            status.setText("Not saved: " + ex.getMessage());
-            status.setTextFill(Color.web(TaskStyleUtils.COLOR_DANGER));
+            report("Not saved, text kept here: " + ex.getMessage(), TaskStyleUtils.COLOR_DANGER);
+            return false;
         }
     }
 
@@ -288,47 +375,131 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
     }
 
     /**
-     * Renders every entry that survives the current search as one dated card,
-     * newest first — the diary read back as a thread.
+     * Renders every entry that survives the current search, newest first — the
+     * diary read back as one markdown document. Each date links back to its day.
      */
     private void renderFeed() {
-        VBox thread = new VBox(16);
-        thread.setPadding(new Insets(4, 16, 12, 4));
-
-        // ponytail: builds a card per entry, no virtualisation. Move to a
-        // ListView with a wrapping cell if a few thousand entries ever lag.
+        StringBuilder body = new StringBuilder();
+        // ponytail: one document holding every entry, no virtualisation. Page it
+        // by month if a few thousand entries ever make loading it sluggish.
         for (DailyReflection entry : matches) {
-            thread.getChildren().add(feedCard(entry));
+            body.append("<article><h2><a href=\"#\" onclick=\"studysync.open('")
+                    .append(entry.getDate())
+                    .append("'); return false;\">")
+                    .append(describe(entry.getDate()))
+                    .append("</a></h2>")
+                    .append(Markdown.toHtml(entry.getReflectionText()))
+                    .append("</article><hr>");
         }
-        if (thread.getChildren().isEmpty()) {
-            Label empty = new Label(searchField.getText() == null || searchField.getText().isBlank()
-                    ? "Nothing written yet — switch to Write and start today's entry."
-                    : "No entries match that search.");
-            TaskStyleUtils.fontItalic(empty, 12);
-            empty.setTextFill(Color.web(TaskStyleUtils.COLOR_MUTED));
-            thread.getChildren().add(empty);
+        if (body.isEmpty()) {
+            body.append("<p class=\"empty\">")
+                    .append(searchField.getText() == null || searchField.getText().isBlank()
+                            ? "Nothing written yet — switch to Write and start today's entry."
+                            : "No entries match that search.")
+                    .append("</p>");
         }
-        feed.setContent(thread);
+        feed.getEngine().loadContent(Markdown.page(body.toString()));
     }
 
-    /** One entry in the thread: its date, its text, and a click to go edit it. */
-    private VBox feedCard(DailyReflection entry) {
-        Label when = new Label(describe(entry.getDate()));
-        TaskStyleUtils.fontSemiBold(when, 13);
-        when.setTextFill(Color.web(TaskStyleUtils.COLOR_PRIMARY));
+    /** Drops a markdown table skeleton in at the caret. */
+    private void insertTable(int columns) {
+        int caret = editor.getCaretPosition();
+        editor.insertText(caret, Markdown.tableSkeleton(columns));
+        editor.requestFocus();
+    }
 
-        Label text = new Label(entry.getReflectionText() == null ? "" : entry.getReflectionText());
-        text.setWrapText(true);
-        text.setStyle("-fx-font-family: 'Georgia', 'Times New Roman', serif; "
-                + "-fx-font-size: 13px; -fx-line-spacing: 0.3em;");
+    /** Writes the open day to a single {@code .md} file the user picks. */
+    private void exportEntry() {
+        if (!flush()) return;
+        String text = editor.getText() == null ? "" : editor.getText();
+        if (text.isBlank()) {
+            report("Nothing to export for this day", TaskStyleUtils.COLOR_MUTED);
+            return;
+        }
 
-        VBox card = new VBox(6, when, text);
-        card.getStyleClass().add("section-card-light");
-        card.setPadding(new Insets(12, 14, 12, 14));
-        card.setCursor(Cursor.HAND);
-        Tooltip.install(card, new Tooltip("Open this day for editing"));
-        card.setOnMouseClicked(e -> goTo(entry.getDate()));
-        return card;
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Export reflection");
+        chooser.setInitialFileName(openDate + ".md");
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Markdown", "*.md"));
+        File target = chooser.showSaveDialog(getScene() == null ? null : getScene().getWindow());
+        if (target == null) {
+            return;
+        }
+        try {
+            Files.writeString(target.toPath(), endWithNewline(text));
+            report("Exported to " + target.getName(), TaskStyleUtils.COLOR_SUCCESS);
+        } catch (IOException ex) {
+            report("Export failed: " + ex.getMessage(), TaskStyleUtils.COLOR_DANGER);
+        }
+    }
+
+    /**
+     * Writes every entry the search currently shows into a folder, one
+     * {@code YYYY-MM-DD.md} per day — an Obsidian vault of daily notes.
+     */
+    private void exportAll() {
+        if (!flush()) return;
+        List<DailyReflection> exportable = new ArrayList<>(matches);
+        if (exportable.isEmpty()) {
+            report("No entries to export", TaskStyleUtils.COLOR_MUTED);
+            return;
+        }
+
+        DirectoryChooser chooser = new DirectoryChooser();
+        chooser.setTitle("Export " + exportable.size() + " reflections to folder");
+        File folder = chooser.showDialog(getScene() == null ? null : getScene().getWindow());
+        if (folder == null) {
+            return;
+        }
+
+        List<String> clashes = new ArrayList<>();
+        for (DailyReflection entry : exportable) {
+            if (Files.exists(folder.toPath().resolve(entry.getDate() + ".md"))) {
+                clashes.add(entry.getDate() + ".md");
+            }
+        }
+        if (!clashes.isEmpty() && !confirmOverwrite(clashes, folder)) {
+            return;
+        }
+
+        int written = 0;
+        try {
+            for (DailyReflection entry : exportable) {
+                Path file = folder.toPath().resolve(entry.getDate() + ".md");
+                String text = entry.getReflectionText() == null ? "" : entry.getReflectionText();
+                Files.writeString(file, endWithNewline(text));
+                written++;
+            }
+            report("Exported " + written + " entries to " + folder.getName(), TaskStyleUtils.COLOR_SUCCESS);
+        } catch (IOException ex) {
+            report("Stopped after " + written + " entries: " + ex.getMessage(), TaskStyleUtils.COLOR_DANGER);
+        }
+    }
+
+    /** Export never silently replaces notes that are already in the folder. */
+    private boolean confirmOverwrite(List<String> clashes, File folder) {
+        String sample = String.join(", ", clashes.subList(0, Math.min(5, clashes.size())));
+        if (clashes.size() > 5) {
+            sample += ", …";
+        }
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                clashes.size() + " file(s) in " + folder.getName() + " will be overwritten: "
+                        + sample + "\n\nContinue?",
+                ButtonType.CANCEL, ButtonType.OK);
+        confirm.initOwner(getScene() == null ? null : getScene().getWindow());
+        confirm.setHeaderText(null);
+        confirm.setTitle("Overwrite existing notes?");
+        return confirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK;
+    }
+
+    /** Exported files end with exactly one newline, without touching the markdown. */
+    private static String endWithNewline(String text) {
+        return text.endsWith("\n") ? text : text + System.lineSeparator();
+    }
+
+    private void report(String message, String color) {
+        status.setText(message);
+        status.setTextFill(Color.web(color));
     }
 
     private void applyFilter(String query) {
@@ -388,6 +559,18 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
         return this;
     }
 
+    /**
+     * Exposed to the rendered diary page as {@code window.studysync}, so a date
+     * in the thread opens that day in the editor. Must stay public for the
+     * WebView bridge to reach it.
+     */
+    public final class DiaryBridge {
+        /** @param isoDate the entry's date, as {@code YYYY-MM-DD} */
+        public void open(String isoDate) {
+            Platform.runLater(() -> goTo(LocalDate.parse(isoDate)));
+        }
+    }
+
     /** Date line plus a one-line preview, so the list reads like a diary index. */
     private final class EntryCell extends ListCell<DailyReflection> {
         @Override
@@ -402,7 +585,7 @@ public class ReflectionDiaryPanel extends BorderPane implements RefreshablePanel
             Label date = new Label(entry.getDate().format(LIST_FORMAT) + relativeSuffix(entry.getDate()));
             TaskStyleUtils.fontSemiBold(date, 12);
 
-            String text = entry.getReflectionText() == null ? "" : entry.getReflectionText().replaceAll("\\s+", " ").trim();
+            String text = Markdown.previewLine(entry.getReflectionText());
             Label preview = new Label(text.length() > 70 ? text.substring(0, 70) + "…" : text);
             TaskStyleUtils.fontNormal(preview, 11);
             preview.setTextFill(Color.web(TaskStyleUtils.COLOR_MUTED));

--- a/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
+++ b/src/main/java/com/studysync/presentation/ui/components/StudyPlannerPanel.java
@@ -2088,10 +2088,7 @@ public class StudyPlannerPanel extends ScrollPane implements RefreshablePanel {
         String text = reflectionArea.getText().trim();
         if (text.isEmpty()) return;
 
-        DailyReflection reflection = new DailyReflection();
-        reflection.setDate(displayDate);
-        reflection.setReflectionText(text);
-        studyService.addDailyReflection(reflection);
+        studyService.saveReflectionText(displayDate, text);
 
         VBox content = new VBox(15);
         content.setPadding(new Insets(20));

--- a/src/test/java/com/studysync/domain/service/DailyReflectionPersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/DailyReflectionPersistenceTest.java
@@ -89,7 +89,7 @@ class DailyReflectionPersistenceTest {
 
     @Test
     void saveReflectionTextUpsertsThenDeletesWhenBlanked() {
-        studyService.saveReflectionText(DAY, "  Got through the whole chapter.  ");
+        studyService.saveReflectionText(DAY, "Got through the whole chapter.");
         assertEquals("Got through the whole chapter.",
                 DailyReflection.findByDate(DAY).orElseThrow().getReflectionText());
 
@@ -100,5 +100,16 @@ class DailyReflectionPersistenceTest {
 
         studyService.saveReflectionText(DAY, "   ");
         assertTrue(DailyReflection.findByDate(DAY).isEmpty());
+    }
+
+    @Test
+    void markdownWhitespaceSurvivesTheRoundTrip() {
+        // Leading spaces make a code block, trailing ones a hard line break:
+        // trimming either would render something the user did not write.
+        String entry = "# Day\n\n    indented code block\n\nline with break  \nnext line\n";
+
+        studyService.saveReflectionText(DAY, entry);
+
+        assertEquals(entry, DailyReflection.findByDate(DAY).orElseThrow().getReflectionText());
     }
 }

--- a/src/test/java/com/studysync/domain/service/DailyReflectionPersistenceTest.java
+++ b/src/test/java/com/studysync/domain/service/DailyReflectionPersistenceTest.java
@@ -1,0 +1,104 @@
+package com.studysync.domain.service;
+
+import com.studysync.domain.entity.DailyReflection;
+import com.studysync.integration.drive.GoogleDriveService;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DailyReflectionPersistenceTest {
+
+    private static final LocalDate DAY = LocalDate.of(2026, 3, 28);
+
+    private HikariDataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+    private StudyService studyService;
+
+    @BeforeEach
+    void setUp() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:studysync-reflections-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        config.setUsername("sa");
+        config.setPassword("");
+        config.setMaximumPoolSize(2);
+        config.setMinimumIdle(1);
+
+        dataSource = new HikariDataSource(config);
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("""
+            CREATE TABLE daily_reflections (
+                id VARCHAR(50) PRIMARY KEY,
+                date DATE NOT NULL UNIQUE,
+                overall_focus_level INTEGER DEFAULT 3,
+                what_to_change_tomorrow TEXT,
+                completed_sessions INTEGER DEFAULT 0,
+                total_goals_achieved INTEGER DEFAULT 0,
+                notes TEXT,
+                reflection_text TEXT,
+                deserve_reward BOOLEAN DEFAULT FALSE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """);
+        DailyReflection.setJdbcTemplate(jdbcTemplate);
+
+        GoogleDriveService googleDriveService = mock(GoogleDriveService.class);
+        when(googleDriveService.saveLocally()).thenReturn(true);
+        DateTimeService dateTimeService = mock(DateTimeService.class);
+        when(dateTimeService.getCurrentDate()).thenReturn(DAY);
+
+        studyService = new StudyService(googleDriveService, dateTimeService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        DailyReflection.setJdbcTemplate(null);
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void secondSaveForSameDayOverwritesInsteadOfDuplicating() {
+        DailyReflection first = new DailyReflection();
+        first.setDate(DAY);
+        first.setReflectionText("Morning thoughts");
+        first.save();
+
+        // A fresh entity for the same day — what the planner's quick box builds.
+        DailyReflection second = new DailyReflection();
+        second.setDate(DAY);
+        second.setReflectionText("Evening thoughts");
+        second.save();
+
+        List<DailyReflection> all = DailyReflection.findAll();
+        assertEquals(1, all.size());
+        assertEquals("Evening thoughts", all.get(0).getReflectionText());
+    }
+
+    @Test
+    void saveReflectionTextUpsertsThenDeletesWhenBlanked() {
+        studyService.saveReflectionText(DAY, "  Got through the whole chapter.  ");
+        assertEquals("Got through the whole chapter.",
+                DailyReflection.findByDate(DAY).orElseThrow().getReflectionText());
+
+        studyService.saveReflectionText(DAY, "Actually, half a chapter.");
+        assertEquals("Actually, half a chapter.",
+                DailyReflection.findByDate(DAY).orElseThrow().getReflectionText());
+        assertEquals(1, DailyReflection.findAll().size());
+
+        studyService.saveReflectionText(DAY, "   ");
+        assertTrue(DailyReflection.findByDate(DAY).isEmpty());
+    }
+}

--- a/src/test/java/com/studysync/presentation/ui/components/MarkdownTest.java
+++ b/src/test/java/com/studysync/presentation/ui/components/MarkdownTest.java
@@ -1,0 +1,63 @@
+package com.studysync.presentation.ui.components;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MarkdownTest {
+
+    private static int count(String haystack, String needle) {
+        int hits = 0;
+        for (int at = haystack.indexOf(needle); at >= 0; at = haystack.indexOf(needle, at + 1)) {
+            hits++;
+        }
+        return hits;
+    }
+
+    @Test
+    void tableSkeletonRendersAsATableWithTheRequestedColumns() {
+        String html = Markdown.toHtml(Markdown.tableSkeleton(6));
+
+        assertTrue(html.contains("<table>"), html);
+        assertEquals(6, count(html, "<th>"));
+        assertEquals(2, count(html, "<tr>") - 1); // one header row plus two empty body rows
+    }
+
+    @Test
+    void filledInTableSurvivesRoundTrip() {
+        String entry = """
+                Tracked the day:
+
+                | Time  | HR | Anxiety |
+                | ----- | -: | ------: |
+                | 09:00 | 70 |    2/10 |
+                | 14:00 | 92 |    5/10 |
+                """;
+
+        String html = Markdown.toHtml(entry);
+
+        assertEquals(3, count(html, "</th>")); // "<th" would also match <thead>
+        assertTrue(html.contains("09:00"), html);
+        assertTrue(html.contains("92"), html);
+    }
+
+    @Test
+    void entryHtmlIsEscapedRatherThanExecuted() {
+        String html = Markdown.toHtml("<script>alert('x')</script>\n\n[go](javascript:alert('x'))");
+
+        assertTrue(html.contains("&lt;script&gt;"), html);
+        assertFalse(html.contains("<script>"), html);
+        assertFalse(html.contains("href=\"javascript:"), html);
+    }
+
+    @Test
+    void previewLineSkipsTableRowsAndStripsMarkers() {
+        assertEquals("Rough afternoon", Markdown.previewLine("## Rough afternoon\n\n| a | b |\n| - | - |"));
+        assertEquals("bold start", Markdown.previewLine("**bold start**"));
+        // Nothing but a table: better to show the first row than nothing at all.
+        assertEquals("| Time | HR |", Markdown.previewLine("| Time | HR |\n| --- | --- |"));
+        assertEquals("", Markdown.previewLine(null));
+    }
+}


### PR DESCRIPTION
## Why

Two problems with the reflection feature:

1. **Past reflections were hard to reach.** The diary tab's sidebar showed only the last 30 days, as bare dates with no preview, no search, and no way to read back through the diary.
2. **Reflections saved from the Study Planner were silently lost.** `daily_reflections.date` is `UNIQUE`, but `DailyReflection.save()` merged on `id`. The planner builds a fresh entity (new UUID) on every save, so the second save for a day raised a unique-constraint violation that died unhandled inside the JavaFX event handler — no dialog, no log, no entry.

## What changed

**Persistence**
- `save()` now merges on `date`, so any caller can write the same day twice.
- New `StudyService.saveReflectionText(date, text)`: upserts, and treats blank text as a delete. Both the diary and the planner's quick box go through it, so editing a day no longer replaces an existing row's other columns with defaults.

**Diary panel** (rewritten)
- Sidebar lists **every** entry ever written (`findAll()`, not the last 30 days), each as date + one-line preview, with a search box that filters on text or date and a live entry count.
- The right-hand pane toggles **Write / Read**. Write is the day editor; Read renders the whole diary as a thread of dated cards, newest first, and the search filters that too. Clicking a card opens that day for editing.
- Autosaves 1.5s after typing stops, on focus loss, on day change, and on Ctrl/Cmd+S — the blocking "Reflection saved!" alert is gone, replaced by an inline `Unsaved… / Saved 14:32` status. Clearing an entry deletes it.
- Panel is a `BorderPane` now, so it fills the tab instead of sitting inside an outer `ScrollPane` at a hardcoded 600px height.

## Testing

`./gradlew build` green; 62 tests pass, including the new `DailyReflectionPersistenceTest`. Its `secondSaveForSameDayOverwritesInsteadOfDuplicating` fails with `JdbcSQLIntegrityConstraintViolationException` if the `KEY (date)` line is reverted, so it pins the bug above.

Also installed and ran the build locally to check the diary end to end.

## Known ceiling

The Read thread builds one card per entry with no virtualisation (marked with a `ponytail:` comment). Fine for a personal diary; worth moving to a `ListView` with a wrapping cell if anyone ever accumulates a few thousand entries.